### PR TITLE
Fix mousetrap library path

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
 				files: [
 					{ src: 'node_modules/jquery/dist/jquery.min.js', dest: 'public_html/lib/jquery.min.js' },
 					{ src: 'node_modules/jquery.cookie/jquery.cookie.js', dest: 'public_html/lib/jquery.cookie.js' },
-					{ src: 'node_modules/Mousetrap/mousetrap.min.js', dest: 'public_html/lib/mousetrap.min.js' },
+					{ src: 'node_modules/mousetrap/mousetrap.min.js', dest: 'public_html/lib/mousetrap.min.js' },
 					{ src: 'node_modules/pathjs/path.js', dest: 'public_html/lib/path.js' },
 					{ src: 'node_modules/underscore/underscore-min.js', dest: 'public_html/lib/underscore.min.js' },
 					{ src: 'node_modules/marked/lib/marked.js', dest: 'public_html/lib/marked.js' },


### PR DESCRIPTION
I fixed invalid `mousetrap` lib path in `gruntfile.js` (uppercase instead of lowercase). 
`grunt copy` was executing without errors even though `mousetrap` lib was not copied which resulted in blank page.