### PR TITLE
Fix broken post fit modes on iOS 10 browsers

### DIFF
--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -13,6 +13,7 @@
 html
     height: 100%
 body
+    max-width: 100vw;
     min-height: 100%
 
 body


### PR DESCRIPTION
With the way the post fit modes work, the image will always be displayed in full size on iOS 10 browsers, regardless of the setting.

I'm not actually sure if this is iOS 10 specific, but I think it might be because of https://twitter.com/thomasfuchs/status/742531231007559680/photo/1.

Setting a max-width on the body fixes it.