### PR TITLE
Add shortcut for deleting posts while in edit mode

### DIFF
--- a/client/html/help_keyboard.tpl
+++ b/client/html/help_keyboard.tpl
@@ -33,6 +33,11 @@ shortcuts:</p>
             <td><kbd>P</kbd></td>
             <td>Focus first post in post list</td>
         </tr>
+
+        <tr>
+            <td><kbd>Delete</kbd></td>
+            <td>Delete post (while in edit mode)</td>
+        </tr>
     </tbody>
 </table>
 

--- a/client/js/views/post_main_view.js
+++ b/client/js/views/post_main_view.js
@@ -77,6 +77,11 @@ class PostMainView {
                 router.show(uri.formatClientLink('post', ctx.nextPostId));
             }
         });
+        keyboard.bind('del', (e) => {
+            if (ctx.editMode) {
+                this.sidebarControl._evtDeleteClick(e);
+            }
+        });
     }
 
     _installSidebar(ctx) {


### PR DESCRIPTION
Add `del` as shortcut for deleting the post while the page is in edit mode