### PR TITLE
preserve search query when using keyboard navigation

### DIFF
--- a/client/js/views/post_main_view.js
+++ b/client/js/views/post_main_view.js
@@ -69,12 +69,12 @@ class PostMainView {
         });
         keyboard.bind(['a', 'left'], () => {
             if (ctx.prevPostId) {
-                router.show(uri.formatClientLink('post', ctx.prevPostId));
+                router.show(ctx.getPostUrl(ctx.prevPostId, ctx.parameters));
             }
         });
         keyboard.bind(['d', 'right'], () => {
             if (ctx.nextPostId) {
-                router.show(uri.formatClientLink('post', ctx.nextPostId));
+                router.show(ctx.getPostUrl(ctx.nextPostId, ctx.parameters));
             }
         });
     }


### PR DESCRIPTION
Currently when using the keyboard to go the next/previous post, the search query is forgot after the first navigation.