### PR TITLE
Override resize mode in home view

### DIFF
--- a/client/js/controls/post_content_control.js
+++ b/client/js/controls/post_content_control.js
@@ -5,18 +5,23 @@ const views = require('../util/views.js');
 const optimizedResize = require('../util/optimized_resize.js');
 
 class PostContentControl {
-    constructor(hostNode, post, viewportSizeCalculator) {
+    constructor(hostNode, post, viewportSizeCalculator, fitFunctionOverride) {
         this._post = post;
         this._viewportSizeCalculator = viewportSizeCalculator;
         this._hostNode = hostNode;
         this._template = views.getTemplate('post-content');
+
+        let fitMode = settings.get().fitMode;
+        if (typeof fitFunctionOverride !== 'undefined') {
+            fitMode = fitFunctionOverride;
+        }
 
         this._currentFitFunction = {
             'fit-both': this.fitBoth,
             'fit-original': this.fitOriginal,
             'fit-width': this.fitWidth,
             'fit-height': this.fitHeight,
-        }[settings.get().fitMode] || this.fitBoth;
+        }[fitMode] || this.fitBoth;
 
         this._install();
 

--- a/client/js/views/home_view.js
+++ b/client/js/views/home_view.js
@@ -62,7 +62,8 @@ class HomeView {
                         window.innerWidth * 0.8,
                         window.innerHeight * 0.7,
                     ];
-                });
+                },
+                'fit-both');
 
             this._postNotesOverlay = new PostNotesOverlayControl(
                 this._postContainerNode.querySelector('.post-overlay'),


### PR DESCRIPTION
The featured post should always use the "both" resize mode in the home view regardless of what the user has set in the post view.

This resolves #144.