### PR TITLE
Mobile styling improvements

### DIFF
--- a/client/css/colors.styl
+++ b/client/css/colors.styl
@@ -55,3 +55,5 @@ $hovered-first-note-point-color = red
 $safety-safe = #88D488
 $safety-sketchy = #F3D75F
 $safety-unsafe = #F3985F
+$scrollbar-thumb-color = $main-color
+$scrollbar-bg-color = $input-enabled-background-color

--- a/client/css/comment-control.styl
+++ b/client/css/comment-control.styl
@@ -123,7 +123,7 @@ $comment-border-color = #DDD
         font-family: 'MS PGothic', 'ＭＳ Ｐゴシック', 'IPAMonaPGothic', 'Trebuchet MS', Verdana, Futura, Arial, Helvetica, sans-serif
         background: #fbfbfb
         color: #111
-        font-size: 12pt
+        font-size: 1em
         line-height: 1
         margin: 0
         padding: 4px

--- a/client/css/comment-control.styl
+++ b/client/css/comment-control.styl
@@ -3,7 +3,6 @@ $comment-header-background-color = $top-navigation-color
 $comment-border-color = #DDD
 
 .comment-container
-    margin: 0 0 1em 0
     padding: 0 0 0 60px
 
     .avatar

--- a/client/css/comment-list-control.styl
+++ b/client/css/comment-list-control.styl
@@ -2,3 +2,8 @@
     list-style-type: none
     margin: 0
     padding: 0
+
+    >li
+        margin-bottom: 1em
+        &:last-child
+            margin-bottom: 0

--- a/client/css/comment-list-view.styl
+++ b/client/css/comment-list-view.styl
@@ -1,15 +1,24 @@
+@import colors
+$comment-border-color = $top-navigation-color
+
 .global-comment-list
     text-align: left
 
     &>ul
         list-style-type: none
-        margin: 1em 0
+        margin: 1em 0 0
         padding: 0
 
+        &>li
+            margin-top: 2em
+            padding-top: 2em
+            border-top: 3px solid $comment-border-color
+            &:first-child
+                margin-top: 0
+                padding-top: 0
+                border-top: none
+
         @media (max-width: 700px)
-            &>li
-                margin-bottom: 5em
-                padding: 1vw
             .post-thumbnail
                 margin-bottom: 1em
                 .thumbnail
@@ -19,7 +28,6 @@
         @media (min-width: 700px)
             &>li
                 padding-left: 13em
-                margin-bottom: 2em
             .post-thumbnail
                 float: left
                 margin: 0 0 1em -13em

--- a/client/css/core-forms.styl
+++ b/client/css/core-forms.styl
@@ -31,13 +31,22 @@ form.horizontal
     margin-bottom: 1em
     .input, .buttons, ul
         display: inline-block
-        vertical-align: middle
+        vertical-align: top
         margin: 0
         padding: 0
         input
-            vertical-align: middle
+            vertical-align: top
     .buttons
         margin-right: 0.5em
+    @media (max-width: 1000px)
+        display: block
+        .input, .buttons, ul
+            display: block
+            margin-top: 0.5em
+            &:first-child
+                margin-top: 0
+        .buttons
+            margin-right: 0
 
 
 
@@ -213,10 +222,13 @@ input[type=submit]
     cursor: pointer
     font-size: 100%
     padding: 0.2em 0.7em
+    border-radius: 0
     border: 2px solid $button-enabled-background-color
     background: $button-enabled-background-color
     color: $button-enabled-text-color
     outline: 0 /* something on Chrome */
+    -moz-appearance: none
+    -webkit-appearance: none
 
     &:disabled
         cursor: default

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -32,6 +32,12 @@ h1, h2, h3
     font-weight: normal
     margin-bottom: 1em
 
+h1
+    font-size: 2em
+
+h2
+    font-size: 1.5em
+
 th
     font-weight: normal
 

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -97,6 +97,10 @@ form .fa-question-circle-o
         padding: 1.8em
         @media (max-width: 1000px)
             padding: 1.5em
+        .content,
+        .content .subcontent
+            >*:last-child
+                margin-bottom: 0
 
 hr
     border: 0

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -59,8 +59,10 @@ form .fa-question-circle-o
     vertical-align: middle
 
 #content-holder
-    padding: 1.5vw
+    padding: 1.5em
     text-align: center
+    @media (max-width: 1000px)
+        padding: 1em
     >.content-wrapper
         box-sizing: border-box /* make max-width: 100% on this element include padding */
         text-align: left
@@ -70,7 +72,9 @@ form .fa-question-circle-o
             margin-top: 0
     >.content-wrapper:not(.transparent)
         background: $top-navigation-color
-        padding: 2vw
+        padding: 1.8em
+        @media (max-width: 1000px)
+            padding: 1.5em
 
 hr
     border: 0
@@ -123,10 +127,12 @@ nav
             li
                 display: inline-block
                 float: left
+                a
+                    padding: 0 1.5em
             #mobile-navigation-toggle
                 display: none
                 width: 100%
-                padding: 0 1.5vw
+                padding: 0 1em
                 line-height: 2.3em
                 font-family: inherit
                 border: none
@@ -148,7 +154,7 @@ nav
                     float: none
                     a
                         display: block
-                        padding: 0 1.5vw
+                        padding: 0 1em
                 #mobile-navigation-toggle
                     display: block
                 &.opened

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -125,6 +125,37 @@ nav
             li
                 display: inline-block
                 float: left
+            #mobile-navigation-toggle
+                display: none
+                width: 100%
+                padding: 0 1.5vw
+                line-height: 2.3em
+                font-family: inherit
+                border: none
+                background: none
+                color: $active-tab-text-color
+                .site-name
+                    display: block
+                    float: left
+                    max-width: 50vw
+                    overflow: hidden
+                    text-overflow: ellipsis
+                .toggle-icon
+                    display: block
+                    float: right
+            @media (max-width: 1000px)
+                text-align: left
+                li
+                    display: none
+                    float: none
+                    a
+                        display: block
+                        padding: 0 1.5vw
+                #mobile-navigation-toggle
+                    display: block
+                &.opened
+                    li
+                        display: block
         ul li[data-name=account],
         ul li[data-name=register],
         ul li[data-name=login],
@@ -141,6 +172,8 @@ nav
             margin-right: 0.6em
             margin-left: calc(0.6em - 1.2em)
             float: left
+            @media (max-width: 1000px)
+                display: none
 
 a .access-key
     text-decoration: underline
@@ -193,6 +226,9 @@ a .access-key
     padding-bottom: 0 !important
     margin-top: 0 !important
     margin-bottom: 0 !important
+
+.table-wrap
+    overflow-x: scroll
 
 /* hack to prevent text from being copied */
 [data-pseudo-content]:before {

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -76,6 +76,17 @@ form .fa-question-circle-o
         margin: 0 auto
         >*:first-child, form h1
             margin-top: 0
+        nav.buttons
+            ul
+                display: block
+                max-width: 100%
+                white-space: nowrap
+                overflow-x: auto
+                &::-webkit-scrollbar
+                    height: 6px
+                    background-color: $scrollbar-bg-color
+                &::-webkit-scrollbar-thumb
+                    background-color: $scrollbar-thumb-color
     >.content-wrapper:not(.transparent)
         background: $top-navigation-color
         padding: 1.8em

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -38,6 +38,11 @@ h1
 h2
     font-size: 1.5em
 
+p,
+ol,
+ul
+    margin: 1em 0
+
 th
     font-weight: normal
 

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -238,7 +238,12 @@ a .access-key
     margin-bottom: 0 !important
 
 .table-wrap
-    overflow-x: scroll
+    overflow-x: auto
+    &::-webkit-scrollbar
+        height: 6px
+        background-color: $scrollbar-bg-color
+    &::-webkit-scrollbar-thumb
+        background-color: $scrollbar-thumb-color
 
 /* hack to prevent text from being copied */
 [data-pseudo-content]:before {

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -21,14 +21,12 @@ body
     margin: 0
     color: $text-color
     font-family: 'Open Sans', sans-serif
-    font-size: 12pt
-    line-height: 18pt
+    font-size: 1em
+    line-height: 1.4
     @media (max-width: 800px)
-        font-size: 10pt
-        line-height: 15pt
+        font-size: 0.875em
     @media (max-width: 1200px)
-        font-size: 11pt
-        line-height: 16.5pt
+        font-size: 0.95em
 
 h1, h2, h3
     font-weight: normal

--- a/client/css/expander-control.styl
+++ b/client/css/expander-control.styl
@@ -16,7 +16,7 @@
             color: mix($text-color, $inactive-link-color)
             font-size: 120%
             i
-                font-size: 12pt
+                font-size: 1em
                 color: $inactive-link-color
                 float: right
                 line-height: 2em

--- a/client/css/help-view.styl
+++ b/client/css/help-view.styl
@@ -16,6 +16,10 @@
         font-size: 1.6em
         &:first-child
             margin-top: 0
+        @media (max-width: 1000px)
+            margin-top: 1.5em
+            &:first-child
+                margin-top: 0
     nav
         ul
             margin: 0 auto

--- a/client/css/home-view.styl
+++ b/client/css/home-view.styl
@@ -15,6 +15,7 @@
             margin: 0 auto 2em auto
 
     form
+        display: inline-block
         width: auto
         vertical-align: middle
         margin: 0 0 2em 0
@@ -52,6 +53,8 @@
             li
                 display: inline
                 white-space: nowrap
+                @media (max-width: 800px)
+                    display: block
             .sep
                 word-spacing: 1.1em
                 background-repeat: no-repeat

--- a/client/css/home-view.styl
+++ b/client/css/home-view.styl
@@ -34,6 +34,8 @@
         display: flex
         align-items: center
         justify-content: center
+        &:empty
+            margin-bottom: 0
 
     nav
         a

--- a/client/css/home-view.styl
+++ b/client/css/home-view.styl
@@ -6,7 +6,7 @@
         margin-bottom: 1em
         h1
             line-height: initial
-            font-size: 30pt
+            font-size: 2.5em
             margin: 0
 
     .messages

--- a/client/css/pager.styl
+++ b/client/css/pager.styl
@@ -8,7 +8,7 @@
     .page
         position: relative
         .page-header
-            margin: 0.5em 0.5em 0.5em 0
+            margin: 0.5em 0
             position: relative
             &:before
                 display: block

--- a/client/css/post-list-view.styl
+++ b/client/css/post-list-view.styl
@@ -70,7 +70,7 @@
                         height: 1em
                         text-align: center
                         line-height: 1em
-                        font-size: 20pt
+                        font-size: 1.6em
                     &.tagged
                         background: rgba(0, 230, 0, 0.7)
                         &:after
@@ -94,7 +94,7 @@
                     height: 1.2em
                     text-align: center
                     line-height: 1em
-                    font-size: 20pt
+                    font-size: 1.6em
                     border: 3px solid
                     &.safety-safe
                         background-color: darken($safety-safe, 5%)

--- a/client/css/post-list-view.styl
+++ b/client/css/post-list-view.styl
@@ -145,12 +145,19 @@
         margin-bottom: 0.75em
         *
             vertical-align: top
+        @media (max-width: 1000px)
+            display: block
     input
         margin-bottom: 0.25em
         margin-right: 0.25em
     input[name=search-text]
         width: 25em
+        @media (max-width: 1000px)
+            display: block
+            width: 100%
+            margin-bottom: 0.5em
     .append
+        vertical-align: middle
         font-size: 0.95em
         color: $inactive-link-color
     .bulk-edit
@@ -163,6 +170,11 @@
         &.hidden
             display: none
     .bulk-edit-tags
+        &.opened
+            .hint
+                @media (max-width: 1000px)
+                    display: block
+                    margin-bottom: 0.5em
         &:not(.opened)
             [type=text],
             .start
@@ -171,8 +183,21 @@
                 display: none
         input[name=tag]
             width: 12em
+            @media (max-width: 1000px)
+                display: block
+                width: 100%
+                margin-bottom: 0.5em
+        .append
+            &.open,
+            &.hint
+                @media (max-width: 1000px)
+                    margin-left: 0
         .hint
             margin-right: 1em
+    .bulk-edit-safety
+        .append
+            @media (max-width: 1000px)
+                margin-left: 0
 
     .safety
         margin-right: 0.25em

--- a/client/css/post-main-view.styl
+++ b/client/css/post-main-view.styl
@@ -33,6 +33,8 @@
                 i
                     font-size: 140%
                 text-align: center
+            @media (max-width: 800px)
+                margin-top: 2em
 
     >.content
         width: 100%
@@ -50,6 +52,7 @@
             order: 2
             min-width: 100%
             max-width: 0
+            margin-right: 0
         >.content
             order: 1
 

--- a/client/css/post-main-view.styl
+++ b/client/css/post-main-view.styl
@@ -138,6 +138,9 @@
                 margin: 0
                 padding: 0
 
+    form
+        width: auto
+
     label:not(.file-dropper)
         margin-bottom: 0.3em
         display: block

--- a/client/css/snapshots-list-view.styl
+++ b/client/css/snapshots-list-view.styl
@@ -8,11 +8,16 @@ $snapshot-merged-background-color = #FEC
 
     ul
         margin: 0 auto
+        padding: 0
         width: 100%
         max-width: 35em
         list-style-type: none
 
         li
+            margin-bottom: 1em
+            &:last-child
+                margin-bottom: 0
+
             .time
                 float: right
 
@@ -39,6 +44,3 @@ $snapshot-merged-background-color = #FEC
                 background: $snapshot-merged-background-color
                 &+.details
                     background: lighten($snapshot-merged-background-color, 50%)
-
-            div.details
-                margin-bottom: 2em

--- a/client/css/tag-categories-view.styl
+++ b/client/css/tag-categories-view.styl
@@ -17,6 +17,12 @@
                 text-align: center
             &.remove, &.set-default
                 white-space: pre
+        th
+            white-space: nowrap
+            &:first-child
+                padding-left: 0
+            &:last-child
+                padding-right: 0
         tfoot
             display: none
     form

--- a/client/css/tag-list-view.styl
+++ b/client/css/tag-list-view.styl
@@ -11,6 +11,7 @@
         th, td
             padding: 0.1em 0.5em
         th
+            white-space: nowrap
             background: $top-navigation-color
         .names
             width: 28%
@@ -47,6 +48,9 @@
         width: auto
     input[name=search-text]
         width: 25em
+        @media (max-width: 1000px)
+            width: 100%
     .append
+        vertical-align: middle
         font-size: 0.95em
         color: $inactive-link-color

--- a/client/css/user-list-view.styl
+++ b/client/css/user-list-view.styl
@@ -34,6 +34,9 @@
         width: auto
     input[name=search-text]
         width: 25em
+        @media (max-width: 1000px)
+            width: 100%
     .append
+        vertical-align: middle
         font-size: 0.95em
         color: $inactive-link-color

--- a/client/html/tag_categories.tpl
+++ b/client/html/tag_categories.tpl
@@ -1,17 +1,19 @@
 <div class='content-wrapper tag-categories'>
     <form>
         <h1>Tag categories</h1>
-        <table>
-            <thead>
-                <tr>
-                    <th class='name'>Category name</th>
-                    <th class='color'>CSS color</th>
-                    <th class='usages'>Usages</th>
-                </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
+        <div class="table-wrap">
+            <table>
+                <thead>
+                    <tr>
+                        <th class='name'>Category name</th>
+                        <th class='color'>CSS color</th>
+                        <th class='usages'>Usages</th>
+                    </tr>
+                </thead>
+                <tbody>
+                </tbody>
+            </table>
+        </div>
 
         <% if (ctx.canCreate) { %>
             <p><a href class='add'>Add new category</a></p>

--- a/client/html/tags_page.tpl
+++ b/client/html/tags_page.tpl
@@ -1,4 +1,4 @@
-<div class='tag-list'>
+<div class='tag-list table-wrap'>
     <% if (ctx.response.results.length) { %>
         <table>
             <thead>

--- a/client/html/top_navigation.tpl
+++ b/client/html/top_navigation.tpl
@@ -1,5 +1,9 @@
 <nav id='top-navigation' class='buttons'><!--
     --><ul><!--
+        --><button id="mobile-navigation-toggle"><!--
+            --><span class="site-name"><%- ctx.name %></span><!--
+            --><span class="toggle-icon"><i class="fa fa-bars"></i></span><!--
+        --></button><!--
         --><% for (let item of ctx.items) { %><!--
             --><% if (item.available) { %><!--
                 --><li data-name='<%- item.key %>'><!--

--- a/client/js/controllers/top_navigation_controller.js
+++ b/client/js/controllers/top_navigation_controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const api = require('../api.js');
+const config = require('../config.js');
 const topNavigation = require('../models/top_navigation.js');
 const TopNavigationView = require('../views/top_navigation_view.js');
 
@@ -62,6 +63,7 @@ class TopNavigationController {
         this._updateNavigationFromPrivileges();
         this._topNavigationView.render({
             items: topNavigation.getAll(),
+            name: config.name
         });
         this._topNavigationView.activate(
             topNavigation.activeItem ? topNavigation.activeItem.key : '');

--- a/client/js/views/help_view.js
+++ b/client/js/views/help_view.js
@@ -44,11 +44,18 @@ class HelpView {
                 subsectionTemplates[section][subsection](ctx));
         }
 
+        views.replaceContent(this._hostNode, sourceNode);
+
         for (let itemNode of
                 sourceNode.querySelectorAll('.primary [data-name]')) {
             itemNode.classList.toggle(
                 'active',
                 itemNode.getAttribute('data-name') === section);
+            if (itemNode.getAttribute('data-name') === section) {
+                itemNode.parentNode.scrollLeft =
+                    itemNode.getBoundingClientRect().left -
+                    itemNode.parentNode.getBoundingClientRect().left
+            }
         }
 
         for (let itemNode of
@@ -56,9 +63,13 @@ class HelpView {
             itemNode.classList.toggle(
                 'active',
                 itemNode.getAttribute('data-name') === subsection);
+            if (itemNode.getAttribute('data-name') === subsection) {
+                itemNode.parentNode.scrollLeft =
+                    itemNode.getBoundingClientRect().left -
+                    itemNode.parentNode.getBoundingClientRect().left
+            }
         }
 
-        views.replaceContent(this._hostNode, sourceNode);
         views.syncScrollPosition();
     }
 }

--- a/client/js/views/post_detail_view.js
+++ b/client/js/views/post_detail_view.js
@@ -26,6 +26,11 @@ class PostDetailView extends events.EventTarget {
         for (let item of this._hostNode.querySelectorAll('[data-name]')) {
             item.classList.toggle(
                 'active', item.getAttribute('data-name') === ctx.section);
+            if (item.getAttribute('data-name') === ctx.section) {
+                item.parentNode.scrollLeft =
+                    item.getBoundingClientRect().left -
+                    item.parentNode.getBoundingClientRect().left
+            }
         }
 
         ctx.hostNode = this._hostNode.querySelector('.post-content-holder');

--- a/client/js/views/tag_view.js
+++ b/client/js/views/tag_view.js
@@ -29,6 +29,11 @@ class TagView extends events.EventTarget {
         for (let item of this._hostNode.querySelectorAll('[data-name]')) {
             item.classList.toggle(
                 'active', item.getAttribute('data-name') === ctx.section);
+            if (item.getAttribute('data-name') === ctx.section) {
+                item.parentNode.scrollLeft =
+                    item.getBoundingClientRect().left -
+                    item.parentNode.getBoundingClientRect().left
+            }
         }
 
         ctx.hostNode = this._hostNode.querySelector('.tag-content-holder');

--- a/client/js/views/top_navigation_view.js
+++ b/client/js/views/top_navigation_view.js
@@ -9,8 +9,22 @@ class TopNavigationView {
         this._hostNode = document.getElementById('top-navigation-holder');
     }
 
+    get _mobileNavigationToggleNode() {
+        return this._hostNode.querySelector('#mobile-navigation-toggle');
+    }
+
+    get _navigationListNode() {
+        return this._hostNode.querySelector('nav > ul');
+    }
+
+    get _navigationLinkNodes() {
+        return this._navigationListNode.querySelectorAll('li > a');
+    }
+
     render(ctx) {
         views.replaceContent(this._hostNode, template(ctx));
+
+        this._bindMobileNavigationEvents();
     }
 
     activate(key) {
@@ -18,6 +32,24 @@ class TopNavigationView {
             itemNode.classList.toggle(
                 'active', itemNode.getAttribute('data-name') === key);
         }
+    }
+
+    _bindMobileNavigationEvents() {
+        this._mobileNavigationToggleNode.addEventListener(
+            'click', e => this._mobileNavigationToggleClick(e));
+
+        for (let navigationLinkNode of this._navigationLinkNodes) {
+            navigationLinkNode.addEventListener(
+                'click', e => this._navigationLinkClick(e));
+        }
+    }
+
+    _mobileNavigationToggleClick(e) {
+        this._navigationListNode.classList.toggle('opened');
+    }
+
+    _navigationLinkClick(e) {
+        this._navigationListNode.classList.remove('opened');
     }
 }
 

--- a/client/js/views/user_view.js
+++ b/client/js/views/user_view.js
@@ -24,11 +24,14 @@ class UserView extends events.EventTarget {
     _install() {
         const ctx = this._ctx;
         views.replaceContent(this._hostNode, template(ctx));
+
         for (let item of this._hostNode.querySelectorAll('[data-name]')) {
+            item.classList.toggle(
+                'active', item.getAttribute('data-name') === ctx.section);
             if (item.getAttribute('data-name') === ctx.section) {
-                item.className = 'active';
-            } else {
-                item.className = '';
+                item.parentNode.scrollLeft =
+                    item.getBoundingClientRect().left -
+                    item.parentNode.getBoundingClientRect().left
             }
         }
 


### PR DESCRIPTION
I've tried tweaking the mobile styles a little bit, namely:

- The top navigation now collapses
- The tags and tag categories tables no longer exceed the window width and are scrollable instead
- The search forms for posts, tags and users no longer exceed the window width and instead wrap their controls into a second line (or a third, if needed)
- The stats on the bottom of the home view no longer exceed the window width and instead display one item per line
- Buttons should no longer have weird gradient backgrounds and border radiuses on iOS browsers
- The comments list has reduced spacing between comments, I think it's still enough this way
- Some other little tweaks like the page counter not having an additional margin on the right for no apparent reason

I wasn't really sure what to do about the JS needed for the mobile navigation toggle, so I just put it somewhere where it's probably very wrong. From the looks of it, I guess you'd normally create a new file under `/control` for that? I'll have to look into that, but I figured I'd create the PR first so I can get some feedback.

Let me know what you think. There's certainly more stuff to improve, like the navigations when editing the account or a tag, I'll try to get to those as well.

Do you have any plans for a new frontend based on something like Vue? Not that this current one is bad or anything (I find it pretty impressive that you basically wrote a whole JS framework yourself), but I think I remember you mentioning that you'd like to do a rewrite in Vue/Angular/React/whatever before.