### PR TITLE
Introduce users:create:any permission and update UI to allow creation of users manually

### DIFF
--- a/client/js/controllers/top_navigation_controller.js
+++ b/client/js/controllers/top_navigation_controller.js
@@ -47,10 +47,12 @@ class TopNavigationController {
             topNavigation.hide('users');
         }
         if (api.isLoggedIn()) {
-            topNavigation.hide('register');
+            if (!api.hasPrivilege('users:create:any')) {
+                topNavigation.hide('register');
+            }
             topNavigation.hide('login');
         } else {
-            if (!api.hasPrivilege('users:create')) {
+            if (!api.hasPrivilege('users:create:self')) {
                 topNavigation.hide('register');
             }
             topNavigation.hide('account');

--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -62,7 +62,8 @@ default_rank: regular
 
 
 privileges:
-    'users:create':                 anonymous
+    'users:create:self':            anonymous # Registration permission
+    'users:create:any':             administrator
     'users:list':                   regular
     'users:view':                   regular
     'users:edit:any:name':          moderator

--- a/server/szurubooru/api/user_api.py
+++ b/server/szurubooru/api/user_api.py
@@ -45,9 +45,6 @@ def create_user(
     ctx.session.add(user)
     ctx.session.commit()
 
-    if ctx.user.user_id is not None:
-        user = ctx.user
-
     return _serialize(ctx, user, force_show_email=True)
 
 

--- a/server/szurubooru/api/user_api.py
+++ b/server/szurubooru/api/user_api.py
@@ -26,7 +26,11 @@ def get_users(
 @rest.routes.post('/users/?')
 def create_user(
         ctx: rest.Context, _params: Dict[str, str] = {}) -> rest.Response:
-    auth.verify_privilege(ctx.user, 'users:create')
+    if ctx.user.user_id is None:
+        auth.verify_privilege(ctx.user, 'users:create:self')
+    else:
+        auth.verify_privilege(ctx.user, 'users:create:any')
+
     name = ctx.get_param_as_string('name')
     password = ctx.get_param_as_string('password')
     email = ctx.get_param_as_string('email', default='')
@@ -40,6 +44,10 @@ def create_user(
             ctx.get_file('avatar', default=b''))
     ctx.session.add(user)
     ctx.session.commit()
+
+    if ctx.user.user_id is not None:
+        user = ctx.user
+
     return _serialize(ctx, user, force_show_email=True)
 
 

--- a/server/szurubooru/tests/api/test_user_creating.py
+++ b/server/szurubooru/tests/api/test_user_creating.py
@@ -6,7 +6,7 @@ from szurubooru.func import users
 
 @pytest.fixture(autouse=True)
 def inject_config(config_injector):
-    config_injector({'privileges': {'users:create': 'regular'}})
+    config_injector({'privileges': {'users:create:self': 'regular'}})
 
 
 def test_creating_user(user_factory, context_factory, fake_datetime):


### PR DESCRIPTION
users:create:any permission and UI update
* Added functionality for a user to directly add users to the application. This allows for registration to be closed for anonymous, but still have users created, by authorized users.
* Added permission users:create:any to handle level that users are allowed to create other users
* Moved old permission users:create to users:create:self