### PR TITLE
Allow thumbnails to be generated even if ffmpeg throws warnings

### DIFF
--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -11,10 +11,6 @@ from szurubooru.func import mime, util
 logger = logging.getLogger(__name__)
 
 
-_SCALE_FIT_FMT = (
-    r"scale='{width}:{height}'")
-
-
 class Image:
     def __init__(self, content: bytes) -> None:
         self.content = content
@@ -39,7 +35,8 @@ class Image:
         cli = [
             '-i', '{path}',
             '-f', 'image2',
-            '-filter:v', _SCALE_FIT_FMT.format(width=width, height=height),
+            '-filter:v', "scale='{width}:{height}'".format(
+                width=width, height=height),
             '-map', '0:v:0',
             '-vframes', '1',
             '-vcodec', 'png',
@@ -82,8 +79,11 @@ class Image:
             '-',
         ])
 
-    def _execute(self, cli: List[str], program: str = 'ffmpeg',
-                 ignore_error_if_data: bool = False) -> bytes:
+    def _execute(
+            self,
+            cli: List[str],
+            program: str = 'ffmpeg',
+            ignore_error_if_data: bool = False) -> bytes:
         extension = mime.get_extension(mime.get_mime_type(self.content))
         assert extension
         with util.create_temp_file(suffix='.' + extension) as handle:

--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 _SCALE_FIT_FMT = (
-    r'scale=\'{width}:{height}\'')
+    r"scale='{width}:{height}'")
 
 
 class Image:


### PR DESCRIPTION
* Poorly formatted MP4 and WEBM sources can cause ffmpeg to throw a lot of warnings. However when there is byte ouptut, the generated thumbnail is valid. Add a bypass for the resize_fill function to allow ffmpeg to error.
* Simplify the ffmpeg video filter scaling parameter