### PR TITLE
client/posts: fix copy tags list of string values error #153

### DIFF
--- a/client/js/models/post.js
+++ b/client/js/models/post.js
@@ -39,6 +39,7 @@ class Post extends events.EventTarget {
 
     get flags()              { return this._flags; }
     get tags()               { return this._tags; }
+    get tagNames()           { return this._tags.map(tag => tag.names[0]); }
     get notes()              { return this._notes; }
     get comments()           { return this._comments; }
     get relations()          { return this._relations; }

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -297,7 +297,7 @@ class PostUploadView extends events.EventTarget {
             let lookalikeNode = rowNode.querySelector(
                 `.lookalikes li:nth-child(${i + 1})`);
             if (lookalikeNode.querySelector('[name=copy-tags]').checked) {
-                uploadable.tags = uploadable.tags.concat(lookalike.post.tags);
+                uploadable.tags = uploadable.tags.concat(lookalike.post.tagNames);
             }
             if (lookalikeNode.querySelector('[name=add-relation]').checked) {
                 uploadable.relations.push(lookalike.post.id);


### PR DESCRIPTION
Issue #153 seems to be because the API expects a list of tag names, but the client is sending the entire list of tag objects when Copy tag is selected on the upload dialog for the similar images. This resulted in ctx.get_param_as_string_list method iterating over objects that weren't strings and returning the "Parameter ‘tags’ must be a list of string values" error message.

I think the simplest fix is to add a get method to the post object to retrieve a list of the tag names. Referencing only the first name in the list of names for a tag seems to be the current practice for identifying the primary name for a tag.