### PR TITLE
Fix post fit calculation on iOS browsers

### DIFF
--- a/client/js/views/post_main_view.js
+++ b/client/js/views/post_main_view.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const iosCorrectedInnerHeight = require('ios-inner-height');
 const router = require('../router.js');
 const views = require('../util/views.js');
 const uri = require('../util/uri.js');
@@ -26,23 +27,20 @@ class PostMainView {
         views.replaceContent(this._hostNode, sourceNode);
         views.syncScrollPosition();
 
-        const postViewNode = document.body.querySelector('.content-wrapper');
         const topNavigationNode =
             document.body.querySelector('#top-navigation');
-
-        const margin = (
-            postViewNode.getBoundingClientRect().top -
-            topNavigationNode.getBoundingClientRect().height);
 
         this._postContentControl = new PostContentControl(
             postContainerNode,
             ctx.post,
             () => {
+                const margin = sidebarNode.getBoundingClientRect().left;
+
                 return [
                     window.innerWidth -
                         postContainerNode.getBoundingClientRect().left -
                         margin,
-                    window.innerHeight -
+                    iosCorrectedInnerHeight() -
                         topNavigationNode.getBoundingClientRect().height -
                         margin * 2,
                 ];

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1482,6 +1482,11 @@
         "loose-envify": "1.3.1"
       }
     },
+    "ios-inner-height": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ios-inner-height/-/ios-inner-height-1.0.3.tgz",
+      "integrity": "sha512-GayJWoFxYHDx/gkfz4nIxNdsqB3nAJQHKV5pDBvig6he8+NxBSYxN+D7oarbqZfW2p6uera3q9NDr4Jgdafiog=="
+    },
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "font-awesome": "^4.6.1",
     "glob": "^7.1.2",
     "html-minifier": "^1.3.1",
+    "ios-inner-height": "^1.0.3",
     "js-cookie": "^2.2.0",
     "js-yaml": "^3.10.0",
     "marked": "^0.3.9",


### PR DESCRIPTION
This should fix the issue I've originally mentioned in #133. It also closes #149 (at least for now, maybe the CSS-based resizing is still something we could add in the future, just for performances sake).

Other browsers shouldn't be affected because the helper library I'm using for calculating a correct viewport height on iOS (independent of the status bar) checks the user agent and just returns `window.innerHeight` (like it was before) in case anything else than iOS is detected.

I've changed the calculation of `margin` because we can't rely on `postViewNode.getBoundingClientRect().top` on iOS, it returns different values depending on the state of the status bar. `sidebarNode.getBoundingClientRect().left` on the other hand stays the same (because it is independent of the available viewport height). Additionally, moving its calculation inside the function passed in the `PostContentControl()` instantiation ensures it gets updated correctly when resizing the viewport and hitting a media query breakpoint where the padding gets smaller/larger.