### PR TITLE
client/posts: fix upload error caused by anonymous node

### DIFF
--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -283,8 +283,10 @@ class PostUploadView extends events.EventTarget {
             uploadable.safety = safetyNode.value;
         }
 
-        uploadable.anonymous =
-            rowNode.querySelector('.anonymous input').checked;
+        const anonymousNode = rowNode.querySelector('.anonymous input:checked');
+        if (anonymousNode) {
+            uploadable.anonymous = true;
+        }
 
         uploadable.flags = [];
         if (rowNode.querySelector('.loop-video input:checked')) {


### PR DESCRIPTION
Anonymous node does not exist in view when a user without anonymous upload permission tries to post upload. So in this case we should check for the existence of anonymousNode first.