### PR TITLE
Added feature: Specify Base URIs other than `/`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -80,9 +80,8 @@ and Docker Compose (version 1.6.0 or greater) already installed.
     Some users may wish to access the service at a different base URI, such
     as `http://example.com/szuru/`, commonly when sharing multiple HTTP
     services on one domain using a reverse proxy. In this case, simply set
-    `BASE_URL="/szuru/"` in the frontend container, and
-    `DATA_URL="/szuru/data/"` in the backend container (unless you are hosting
-    your data on a different domain).
+    `BASE_URL="/szuru/"` in the frontend container (unless you are hosting your
+    data on a different domain).
 
     You should set your reverse proxy to proxy `http(s)://example.com/szuru` to
     `http://<internal IP or hostname of frontend container>/`. For an NGINX

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,3 +63,43 @@ and Docker Compose (version 1.6.0 or greater) already installed.
     # To stop
     user@host:szuru$ docker-compose down
     ```
+
+### Additional Features
+
+1. **Using a seperate domain to host static files (image content)**
+
+    If you want to host your website on, (`http://example.com/`) but want
+    to serve the images on a different domain, (`http://static.example.com/`)
+    then you can run the backend container with an additional environment
+    variable `DATA_URL=http://static.example.com/`. Make sure that this
+    additional host has access contents to the `/data` volume mounted in the
+    backend.
+
+2. **Setting a specific base URI for proxying**
+
+    Some users may wish to access the service at a different base URI, such
+    as `http://example.com/szuru/`, commonly when sharing multiple HTTP
+    services on one domain using a reverse proxy. In this case, simply set
+    `BASE_URL="/szuru/"` in the frontend container, and
+    `DATA_URL="/szuru/data/"` in the backend container (unless you are hosting
+    your data on a different domain).
+
+    You should set your reverse proxy to proxy `http(s)://example.com/szuru` to
+    `http://<internal IP or hostname of frontend container>/`. For an NGINX
+    reverse proxy, that will appear as:
+
+    ```nginx
+    location /szuru {
+        proxy_http_version 1.1;
+        proxy_pass http://<internal IP or hostname of frontend container>/;
+
+        proxy_set_header Host              $http_host;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme          $scheme;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Script-Name     /szuru;
+    }
+    ```

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,9 +8,10 @@ COPY . ./
 
 ARG BUILD_INFO="docker-latest"
 ARG CLIENT_BUILD_ARGS=""
-RUN node build.js ${CLIENT_BUILD_ARGS}
+RUN BASE_URL="__BASEURL__" node build.js ${CLIENT_BUILD_ARGS}
 
-RUN find public/ -type f -size +5k -print0 | xargs -0 -- gzip -6 -k
+RUN find public/ -name public/index.html -prune -o -type f -size +5k \
+        -print0 | xargs -0 -- gzip -6 -k
 
 
 FROM nginx:alpine
@@ -21,6 +22,7 @@ RUN \
     echo "#!/bin/sh" >> /init && \
     echo 'sed -i "s|__BACKEND__|${BACKEND_HOST}|" /etc/nginx/nginx.conf' \
         >> /init && \
+    echo 'sed -i "s|__BASEURL__|${BASE_URL:-/}|" /var/www/index.htm' >> /init && \
     echo 'exec nginx -g "daemon off;"' >> /init && \
     chmod a+x /init
 

--- a/client/build.js
+++ b/client/build.js
@@ -65,7 +65,10 @@ function bundleHtml() {
     const underscore = require('underscore');
     const babelify = require('babelify');
     const baseHtml = readTextFile('./html/index.htm', 'utf-8');
-    writeFile('./public/index.htm', minifyHtml(baseHtml));
+    const baseUrl = process.env.BASE_URL ? process.env.BASE_URL : '/';
+    const finalHtml = baseHtml.replace(
+        '<!-- Base HTML Placeholder -->', `<base href="${baseUrl}"/>`);
+    writeFile('./public/index.htm', minifyHtml(finalHtml));
 
     glob('./html/**/*.tpl', {}, (er, files) => {
         let compiledTemplateJs = '\'use strict\'\n';

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -6,7 +6,7 @@
     font-family: 'Open Sans';
     font-style: normal;
     font-weight: 400;
-    src: local('Open Sans'), local('OpenSans'), url(/fonts/open_sans.woff2) format('woff2');
+    src: local('Open Sans'), local('OpenSans'), url(fonts/open_sans.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 
 /* make <body> cover entire viewport */
@@ -239,7 +239,7 @@ a .access-key
     width: 20px
     height: 20px
     &.empty
-        background-image: url('/img/transparency_grid.png')
+        background-image: url('img/transparency_grid.png')
         background-repeat: repeat
         background-size: initial
     img

--- a/client/css/post-content-control.styl
+++ b/client/css/post-content-control.styl
@@ -1,6 +1,6 @@
 .post-container
     .post-content.transparency-grid img
-        background: url('/img/transparency_grid.png')
+        background: url('img/transparency_grid.png')
 
     text-align: center
     .post-content

--- a/client/html/index.htm
+++ b/client/html/index.htm
@@ -9,7 +9,7 @@
     <meta name='msapplication-TileColor' content='#ffffff'/>
     <meta name="msapplication-TileImage" content="/img/mstile-150x150.png">
     <title>Loading...</title>
-    <base href="/"/>
+    <!-- Base HTML Placeholder -->
     <link href='css/app.min.css' rel='stylesheet' type='text/css'/>
     <link href='css/vendor.min.css' rel='stylesheet' type='text/css'/>
     <link rel='shortcut icon' type='image/png' href='img/favicon.png'/>

--- a/client/html/index.htm
+++ b/client/html/index.htm
@@ -9,23 +9,24 @@
     <meta name='msapplication-TileColor' content='#ffffff'/>
     <meta name="msapplication-TileImage" content="/img/mstile-150x150.png">
     <title>Loading...</title>
-    <link href='/css/app.min.css' rel='stylesheet' type='text/css'/>
-    <link href='/css/vendor.min.css' rel='stylesheet' type='text/css'/>
-    <link rel='shortcut icon' type='image/png' href='/img/favicon.png'/>
-    <link rel='apple-touch-icon' sizes='180x180' href='/img/apple-touch-icon.png'/>
-    <link rel='apple-touch-startup-image' href='/img/apple-touch-startup-image-640x1136.png' media='(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)'/>
-    <link rel='apple-touch-startup-image' href='/img/apple-touch-startup-image-750x1294.png' media='(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)'/>
-    <link rel='apple-touch-startup-image' href='/img/apple-touch-startup-image-1242x2148.png' media='(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)'/>
-    <link rel='apple-touch-startup-image' href='/img/apple-touch-startup-image-1125x2436.png' media='(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)'/>
-    <link rel='apple-touch-startup-image' href='/img/apple-touch-startup-image-1536x2048.png' media='(min-device-width: 768px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
-    <link rel='apple-touch-startup-image' href='/img/apple-touch-startup-image-1668x2224.png' media='(min-device-width: 834px) and (max-device-width: 834px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
-    <link rel='apple-touch-startup-image' href='/img/apple-touch-startup-image-2048x2732.png' media='(min-device-width: 1024px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
-    <link rel='manifest' href='/manifest.json'/>
+    <base href="/"/>
+    <link href='css/app.min.css' rel='stylesheet' type='text/css'/>
+    <link href='css/vendor.min.css' rel='stylesheet' type='text/css'/>
+    <link rel='shortcut icon' type='image/png' href='img/favicon.png'/>
+    <link rel='apple-touch-icon' sizes='180x180' href='img/apple-touch-icon.png'/>
+    <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-640x1136.png' media='(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)'/>
+    <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-750x1294.png' media='(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)'/>
+    <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-1242x2148.png' media='(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)'/>
+    <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-1125x2436.png' media='(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)'/>
+    <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-1536x2048.png' media='(min-device-width: 768px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
+    <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-1668x2224.png' media='(min-device-width: 834px) and (max-device-width: 834px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
+    <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-2048x2732.png' media='(min-device-width: 1024px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
+    <link rel='manifest' href='manifest.json'/>
 </head>
 <body>
     <div id='top-navigation-holder'></div>
     <div id='content-holder'></div>
-    <script type='text/javascript' src='/js/vendor.min.js'></script>
-    <script type='text/javascript' src='/js/app.min.js'></script>
+    <script type='text/javascript' src='js/vendor.min.js'></script>
+    <script type='text/javascript' src='js/app.min.js'></script>
 </body>
 </html>

--- a/client/js/api.js
+++ b/client/js/api.js
@@ -9,6 +9,18 @@ const uri = require('./util/uri.js');
 let fileTokens = {};
 let remoteConfig = null;
 
+function getCookieName() {
+    const bases = document.getElementsByTagName('base');
+    if (bases.length) {
+        let baseHref = bases[0].href;
+        baseHref = baseHref.replace('/', '');
+        return 'szuru-' + baseHref;
+    } else {
+        return 'szuru';
+    }
+}
+const cookieName = getCookieName();
+
 class Api extends events.EventTarget {
     constructor() {
         super();
@@ -126,7 +138,7 @@ class Api extends events.EventTarget {
     }
 
     loginFromCookies() {
-        const auth = cookies.getJSON('auth');
+        const auth = cookies.getJSON(cookieName);
         return auth && auth.user && auth.token ?
             this.loginWithToken(auth.user, auth.token, true) :
             Promise.resolve();
@@ -169,7 +181,7 @@ class Api extends events.EventTarget {
             this.post('/user-token/' + userName, userTokenRequest)
                 .then(response => {
                     cookies.set(
-                        'auth',
+                        cookieName,
                         {'user': userName, 'token': response.token},
                         options);
                     this.userName = userName;

--- a/client/js/api.js
+++ b/client/js/api.js
@@ -256,7 +256,7 @@ class Api extends events.EventTarget {
 
     _getFullUrl(url) {
         const fullUrl =
-            ('/api/' + url).replace(/([^:])\/+/g, '$1/');
+            ('api/' + url).replace(/([^:])\/+/g, '$1/');
         const matches = fullUrl.match(/^([^?]*)\??(.*)$/);
         const baseUrl = matches[1];
         const request = matches[2];
@@ -327,7 +327,7 @@ class Api extends events.EventTarget {
         let abortFunction = () => {};
         let returnedPromise = new Promise((resolve, reject) => {
             let uploadPromise = this._rawRequest(
-                '/uploads', request.post, {}, {content: file}, options);
+                'uploads', request.post, {}, {content: file}, options);
             abortFunction = () => uploadPromise.abort();
             return uploadPromise.then(
                 response => {

--- a/client/js/controllers/top_navigation_controller.js
+++ b/client/js/controllers/top_navigation_controller.js
@@ -28,7 +28,7 @@ class TopNavigationController {
     }
 
     _updateNavigationFromPrivileges() {
-        topNavigation.get('account').url = '/user/' + api.userName;
+        topNavigation.get('account').url = 'user/' + api.userName;
         topNavigation.get('account').imageUrl =
             api.user ? api.user.avatarUrl : null;
 

--- a/client/js/models/top_navigation.js
+++ b/client/js/models/top_navigation.js
@@ -76,23 +76,23 @@ class TopNavigation extends events.EventTarget {
 
 function _makeTopNavigation() {
     const ret = new TopNavigation();
-    ret.add('home', new TopNavigationItem('H', 'Home', '/'));
-    ret.add('posts', new TopNavigationItem('P', 'Posts', '/posts'));
-    ret.add('upload', new TopNavigationItem('U', 'Upload', '/upload'));
-    ret.add('comments', new TopNavigationItem('C', 'Comments', '/comments'));
-    ret.add('tags', new TopNavigationItem('T', 'Tags', '/tags'));
-    ret.add('users', new TopNavigationItem('S', 'Users', '/users'));
-    ret.add('account', new TopNavigationItem('A', 'Account', '/user/{me}'));
-    ret.add('register', new TopNavigationItem('R', 'Register', '/register'));
-    ret.add('login', new TopNavigationItem('L', 'Log in', '/login'));
-    ret.add('logout', new TopNavigationItem('O', 'Logout', '/logout'));
-    ret.add('help', new TopNavigationItem('E', 'Help', '/help'));
+    ret.add('home', new TopNavigationItem('H', 'Home', ''));
+    ret.add('posts', new TopNavigationItem('P', 'Posts', 'posts'));
+    ret.add('upload', new TopNavigationItem('U', 'Upload', 'upload'));
+    ret.add('comments', new TopNavigationItem('C', 'Comments', 'comments'));
+    ret.add('tags', new TopNavigationItem('T', 'Tags', 'tags'));
+    ret.add('users', new TopNavigationItem('S', 'Users', 'users'));
+    ret.add('account', new TopNavigationItem('A', 'Account', 'user/{me}'));
+    ret.add('register', new TopNavigationItem('R', 'Register', 'register'));
+    ret.add('login', new TopNavigationItem('L', 'Log in', 'login'));
+    ret.add('logout', new TopNavigationItem('O', 'Logout', 'logout'));
+    ret.add('help', new TopNavigationItem('E', 'Help', 'help'));
     ret.add(
         'settings',
         new TopNavigationItem(
             null,
             '<i class=\'fa fa-cog\'></i>',
-            '/settings'));
+            'settings'));
     return ret;
 }
 

--- a/client/js/util/uri.js
+++ b/client/js/util/uri.js
@@ -51,7 +51,7 @@ function formatClientLink(...values) {
             parts.push(escapeParam(value.toString()));
         }
     }
-    return '/' + parts.join('/');
+    return parts.join('/');
 }
 
 module.exports = {

--- a/server/szurubooru/config.py
+++ b/server/szurubooru/config.py
@@ -28,7 +28,7 @@ def docker_config() -> Dict:
     return {
         'debug': True,
         'show_sql': int(os.getenv('LOG_SQL', 0)),
-        'data_url': os.getenv('DATA_URL', '/data/'),
+        'data_url': os.getenv('DATA_URL', 'data/'),
         'data_dir': '/data/',
         'database': 'postgres://%(user)s:%(pass)s@%(host)s:%(port)d/%(db)s' % {
             'user': os.getenv('POSTGRES_USER'),


### PR DESCRIPTION
This allows users to specify a different URI prefix other than `/`: e.g serve the web application on something like `http://example.com/mybooru/` instead of just `http://example.com/`. This allows users to serve mutiple web applications off the same domain name.

This basically leverages on using the HTML `<base>` tag. Docker users set the base href with a `BASE_URL` environment at runtime, while non-docker users can pass it to the `build.js` script. The base href defaults to `/`, so this shouldn't affect the deployment of any existing users. 
The biggest changes were made to `router.js` which reads the base tag from the DOM to figure out the proper routing URIs. The rest of the changes mostly consist of just dropping the leading slash from any URIs to make the base tag work.

For testing: I coded up this feature about a month ago because I needed to run two instances of this on my server. I ran this on both deployments for about a month and haven't noticed any bugs or had any reported to me. However, both instances are run inside a LAN, and only see about 5 users each.

I wouldn't consider myself a frontend/JS dev, so you should inspect these changes carefully to make sure I'm not violating best practices, etc.