### PR TITLE
client: Stop showing mp4 files as undefined

### DIFF
--- a/client/html/post_merge_side.tpl
+++ b/client/html/post_merge_side.tpl
@@ -36,6 +36,7 @@
                     'image/jpeg': 'JPEG',
                     'image/png': 'PNG',
                     'video/webm': 'WEBM',
+                    'video/mp4': 'MPEG-4',
                     'application/x-shockwave-flash': 'SWF',
                 }[ctx.post.mimeType] +
                 ' (' +

--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -9,6 +9,7 @@
                     'image/jpeg': 'JPEG',
                     'image/png': 'PNG',
                     'video/webm': 'WEBM',
+                    'video/mp4': 'MPEG-4',
                     'application/x-shockwave-flash': 'SWF',
                 }[ctx.post.mimeType] %>
             </a>


### PR DESCRIPTION
Posts with MIME type `video/mp4` would either show the content format as undefined or not at all. This fixes that.