### PR TITLE
New flag: check sound

### DIFF
--- a/client/html/help_search_posts.tpl
+++ b/client/html/help_search_posts.tpl
@@ -71,6 +71,10 @@
             <td>given type of posts. <code>&lt;value&gt;</code> can be either <code>image</code>, <code>animation</code> (or <code>animated</code> or <code>anim</code>), <code>flash</code> (or <code>swf</code>) or <code>video</code> (or <code>webm</code>).</td>
         </tr>
         <tr>
+            <td><code>flag</code></td>
+            <td>having given flag. <code>&lt;value&gt;</code> can be either <code>loop</code> or <code>sound</code>.</td>
+        </tr>
+        <tr>
             <td><code>content-checksum</code></td>
             <td>having given SHA1 checksum</td>
         </tr>

--- a/client/html/post_edit_sidebar.tpl
+++ b/client/html/post_edit_sidebar.tpl
@@ -50,6 +50,11 @@
                     name: 'loop',
                     checked: ctx.post.flags.includes('loop'),
                 }) %>
+                <%= ctx.makeCheckbox({
+                    text: 'Sound',
+                    name: 'sound',
+                    checked: ctx.post.flags.includes('sound'),
+                }) %>
             </section>
         <% } %>
 

--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -14,6 +14,9 @@
                 }[ctx.post.mimeType] %>
             </a>
             (<%- ctx.post.canvasWidth %>x<%- ctx.post.canvasHeight %>)
+            <% if (ctx.post.flags.includes('sound')) { %>
+                <i class='fa fa-volume-up'></i>
+            <% } %>
         </section>
 
         <section class='upload-info'>

--- a/client/js/controls/post_edit_sidebar_control.js
+++ b/client/js/controls/post_edit_sidebar_control.js
@@ -331,9 +331,7 @@ class PostEditSidebarControl extends events.EventTarget {
                         .value.toLowerCase() :
                     undefined,
 
-                flags: this._loopVideoInputNode ?
-                    (this._loopVideoInputNode.checked ? ['loop'] : []) :
-                    undefined,
+                flags: this._videoFlags,
 
                 tags: this._tagInputNode ?
                     misc.splitByWhitespace(this._tagInputNode.value) :
@@ -373,6 +371,18 @@ class PostEditSidebarControl extends events.EventTarget {
 
     get _loopVideoInputNode() {
         return this._formNode.querySelector('.flags input[name=loop]');
+    }
+
+    get _soundVideoInputNode() {
+        return this._formNode.querySelector('.flags input[name=sound]');
+    }
+
+    get _videoFlags() {
+        if (!this._loopVideoInputNode) return undefined;
+        let ret = [];
+        if (this._loopVideoInputNode.checked) ret.push('loop');
+        if (this._soundVideoInputNode.checked) ret.push('sound');
+        return ret;
     }
 
     get _relationsInputNode() {

--- a/server/szurubooru/api/post_api.py
+++ b/server/szurubooru/api/post_api.py
@@ -65,6 +65,7 @@ def create_post(
     posts.update_post_relations(post, relations)
     posts.update_post_notes(post, notes)
     posts.update_post_flags(post, flags)
+    posts.test_sound(post, content)
     if ctx.has_file('thumbnail'):
         posts.update_post_thumbnail(post, ctx.get_file('thumbnail'))
     ctx.session.add(post)

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -222,7 +222,7 @@ class PostSerializer(serialization.BaseSerializer):
         return get_post_thumbnail_url(self.post)
 
     def serialize_flags(self) -> Any:
-        return self.post.flags
+        return [x for x in self.post.flags.split(',') if x]
 
     def serialize_tags(self) -> Any:
         return [
@@ -356,7 +356,7 @@ def create_post(
     post.safety = model.Post.SAFETY_SAFE
     post.user = user
     post.creation_time = datetime.utcnow()
-    post.flags = []
+    post.flags = ''
 
     post.type = ''
     post.checksum = ''
@@ -628,7 +628,7 @@ def update_post_flags(post: model.Post, flags: List[str]) -> None:
             raise InvalidPostFlagError(
                 'Flag must be one of %r.' % list(FLAG_MAP.values()))
         target_flags.append(flag)
-    post.flags = target_flags
+    post.flags = ','.join(target_flags)
 
 
 def feature_post(post: model.Post, user: Optional[model.User]) -> None:

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -81,6 +81,7 @@ TYPE_MAP = {
 
 FLAG_MAP = {
     model.Post.FLAG_LOOP: 'loop',
+    model.Post.FLAG_SOUND: 'sound',
 }
 
 

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -474,6 +474,17 @@ def generate_alternate_formats(post: model.Post, content: bytes) \
     return new_posts
 
 
+def test_sound(post: model.Post, content: bytes) -> None:
+    assert post
+    assert content
+    if mime.is_video(mime.get_mime_type(content)):
+        if images.Image(content).check_for_sound():
+            flags = [x for x in post.flags.split(',') if x]
+            if model.Post.FLAG_SOUND not in flags:
+                flags.append(model.Post.FLAG_SOUND)
+            update_post_flags(post, flags)
+
+
 def update_post_content(post: model.Post, content: Optional[bytes]) -> None:
     assert post
     if not content:

--- a/server/szurubooru/func/snapshots.py
+++ b/server/szurubooru/func/snapshots.py
@@ -29,7 +29,7 @@ def get_post_snapshot(post: model.Post) -> Dict[str, Any]:
         'source': post.source,
         'safety': post.safety,
         'checksum': post.checksum,
-        'flags': post.flags,
+        'flags': sorted(post.flags.split(',')),
         'featured': post.is_featured,
         'tags': sorted([tag.first_name for tag in post.tags]),
         'relations': sorted([rel.post_id for rel in post.relations]),

--- a/server/szurubooru/migrations/versions/1cd4c7b22846_change_flags_column_to_string.py
+++ b/server/szurubooru/migrations/versions/1cd4c7b22846_change_flags_column_to_string.py
@@ -1,0 +1,63 @@
+'''
+Change flags column to string
+
+Revision ID: 1cd4c7b22846
+Created at: 2018-09-21 19:37:27.686568
+'''
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '1cd4c7b22846'
+down_revision = 'a39c7f98a7fa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    op.alter_column('post', 'flags', new_column_name='oldflags')
+    op.add_column('post', sa.Column(
+        'flags', sa.Unicode(200), default='', nullable=True))
+    posts = sa.Table(
+        'post',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('flags', sa.Unicode(200), default='', nullable=True),
+        sa.Column('oldflags', sa.PickleType(), nullable=True),
+    )
+    for row in conn.execute(posts.select()):
+        newflag = ','.join(row.oldflags)
+        conn.execute(
+            # pylint: disable=no-value-for-parameter
+            posts.update().where(
+                posts.c.id == row.id
+            ).values(
+                flags=newflag
+            )
+        )
+    op.drop_column('post', 'oldflags')
+
+
+def downgrade():
+    conn = op.get_bind()
+    op.alter_column('post', 'flags', new_column_name='oldflags')
+    op.add_column('post', sa.Column('flags', sa.PickleType(), nullable=True))
+    posts = sa.Table(
+        'post',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('flags', sa.PickleType(), nullable=True),
+        sa.Column('oldflags', sa.Unicode(200), default='', nullable=True),
+    )
+    for row in conn.execute(posts.select()):
+        newflag = [x for x in row.oldflags.split(',') if x]
+        conn.execute(
+            # pylint: disable=no-value-for-parameter
+            posts.update().where(
+                posts.c.id == row.id
+            ).values(
+                flags=newflag
+            )
+        )
+    op.drop_column('post', 'oldflags')

--- a/server/szurubooru/model/post.py
+++ b/server/szurubooru/model/post.py
@@ -154,6 +154,7 @@ class Post(Base):
     TYPE_FLASH = 'flash'
 
     FLAG_LOOP = 'loop'
+    FLAG_SOUND = 'sound'
 
     # basic meta
     post_id = sa.Column('id', sa.Integer, primary_key=True)

--- a/server/szurubooru/model/post.py
+++ b/server/szurubooru/model/post.py
@@ -169,7 +169,7 @@ class Post(Base):
     last_edit_time = sa.Column('last_edit_time', sa.DateTime)
     safety = sa.Column('safety', sa.Unicode(32), nullable=False)
     source = sa.Column('source', sa.Unicode(200))
-    flags = sa.Column('flags', sa.PickleType, default=None)
+    flags = sa.Column('flags', sa.Unicode(200), default='')
 
     # content description
     type = sa.Column('type', sa.Unicode(32), nullable=False)

--- a/server/szurubooru/search/configs/post_search_config.py
+++ b/server/szurubooru/search/configs/post_search_config.py
@@ -35,6 +35,14 @@ def _safety_transformer(value: str) -> str:
     return search_util.enum_transformer(available_values, value)
 
 
+def _flag_transformer(value: str) -> str:
+    available_values = {
+        'loop': model.Post.FLAG_LOOP,
+        'sound': model.Post.FLAG_SOUND,
+    }
+    return '%' + search_util.enum_transformer(available_values, value) + '%'
+
+
 def _create_score_filter(score: int) -> Filter:
     def wrapper(
             query: SaQuery,
@@ -325,6 +333,12 @@ class PostSearchConfig(BaseSearchConfig):
             (
                 ['note-text'],
                 _note_filter
+            ),
+
+            (
+                ['flag'],
+                search_util.create_str_filter(
+                    model.Post.flags, _flag_transformer)
             ),
         ])
 


### PR DESCRIPTION
A lot GIF-like video loops (GFYs or whatever people usually call them) on the internet nowadays come with sound. This allows users to add a sound flag to video posts so that others can know if a post has sound before playing a clip.

First commit enables a sound flag on the backend, shows if it's present in the post view, and allows for setting during upload and post edit.

Second commit allows for flags to be searched, with `flag:sound` and `flag:loop`. The best way to do this was to migrate the flags column in the post table from PickleType/binary to varchar, stored as a comma delimited list. This allows for the column to be queried easily (I'm not sure if it's even possible to query a PickleType in SQLAlchemy, as I can't find any documentation or examples) and also has the side benefit of being human-readable.

Looking through the commit history, I'm not exactly sure why PickleType was used in the first place, so I'm not sure if I'm losing any capabilities with this change.