### PR TITLE
Use the document base href to generate absolute url

### DIFF
--- a/client/js/models/post.js
+++ b/client/js/models/post.js
@@ -276,7 +276,7 @@ class Post extends events.EventTarget {
             _user:          response.user,
             _safety:        response.safety,
             _contentUrl:    response.contentUrl,
-            _fullContentUrl: new URL(response.contentUrl, window.location.href).href,
+            _fullContentUrl: new URL(response.contentUrl, document.getElementsByTagName('base')[0].href).href,
             _thumbnailUrl:  response.thumbnailUrl,
             _canvasWidth:   response.canvasWidth,
             _canvasHeight:  response.canvasHeight,


### PR DESCRIPTION
Otherwise the image link send to IQDB/google images will be invalid