### PR TITLE
Fix missing transparency grid

### DIFF
--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -239,7 +239,7 @@ a .access-key
     width: 20px
     height: 20px
     &.empty
-        background-image: url('img/transparency_grid.png')
+        background-image: url('/img/transparency_grid.png')
         background-repeat: repeat
         background-size: initial
     img

--- a/client/css/post-content-control.styl
+++ b/client/css/post-content-control.styl
@@ -1,6 +1,6 @@
 .post-container
     .post-content.transparency-grid img
-        background: url('img/transparency_grid.png')
+        background: url('/img/transparency_grid.png')
 
     text-align: center
     .post-content


### PR DESCRIPTION
This patch fix a 404 for `transparency_grid.png`.

## Issue

The css file is located at `/css` and `transparency_grid.png` is copied to `/img`.

https://github.com/rr-/szurubooru/blob/1dd43717af31bded0911315968305046648989a2/client/build.js#L228

The relative path in CSS caused the image to be loaded from `/css/img` instead of `/img`.

## Solution

Change the image path in CSS to absolute path.