### PR TITLE
Fix transparency grid for alternate base URIs

### DIFF
--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -239,7 +239,7 @@ a .access-key
     width: 20px
     height: 20px
     &.empty
-        background-image: url('/img/transparency_grid.png')
+        background-image: url('../img/transparency_grid.png')
         background-repeat: repeat
         background-size: initial
     img

--- a/client/css/post-content-control.styl
+++ b/client/css/post-content-control.styl
@@ -1,6 +1,6 @@
 .post-container
     .post-content.transparency-grid img
-        background: url('/img/transparency_grid.png')
+        background: url('../img/transparency_grid.png')
 
     text-align: center
     .post-content


### PR DESCRIPTION
The patch made in #220 does not work if `BASE_URI` is set to anything but the default value. This still fixes the original issue while keeping the URI path relative, so that it is compatible with all base URIs