### PR TITLE
client/posts: Add some UI icons

### DIFF
--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -14,8 +14,9 @@
                 }[ctx.post.mimeType] %>
             </a>
             (<%- ctx.post.canvasWidth %>x<%- ctx.post.canvasHeight %>)
-            <% if (ctx.post.flags.includes('sound')) { %>
-                <i class='fa fa-volume-up'></i>
+            <% if (ctx.post.flags.length) { %><!--
+                --><% if (ctx.post.flags.includes('loop')) { %><i class='fa fa-repeat'></i><% } %><!--
+                --><% if (ctx.post.flags.includes('sound')) { %><i class='fa fa-volume-up'></i><% } %>
             <% } %>
         </section>
 

--- a/client/html/posts_page.tpl
+++ b/client/html/posts_page.tpl
@@ -8,7 +8,11 @@
                             href='<%= ctx.canViewPosts ? ctx.getPostUrl(post.id, ctx.parameters) : '' %>'>
                         <%= ctx.makeThumbnail(post.thumbnailUrl) %>
                         <span class='type' data-type='<%- post.type %>'>
-                            <%- post.type %>
+                            <% if (post.type == 'video' || post.type == 'flash' || post.type == 'animation') { %>
+                                <span class='icon'><i class='fa fa-film'></i></span>
+                            <% } else { %>
+                                <%- post.type %>
+                            <% } %>
                         </span>
                         <% if (post.score || post.favoriteCount || post.commentCount) { %>
                             <span class='stats'>


### PR DESCRIPTION
Adds a 'loop' icon in the post view sidebar to indicate if the loop flag is set, similar to how there's an icon to indicate if the sound flag is set.

Also, in the post listing page, the labels 'video', 'animation', and 'flash' have been replaced with [this icon](https://fontawesome.com/v4.7.0/icon/film), which looks cleaner IMO