### PR TITLE
Add source searching

### DIFF
--- a/client/html/help_search_posts.tpl
+++ b/client/html/help_search_posts.tpl
@@ -39,6 +39,10 @@
             <td>favorited by given user (accepts wildcards)</td>
         </tr>
         <tr>
+            <td><code>source</code></td>
+            <td>having given source URL (accepts wildcards)</td>
+        </tr>
+        <tr>
             <td><code>tag-count</code></td>
             <td>having given number of tags</td>
         </tr>

--- a/server/szurubooru/search/configs/post_search_config.py
+++ b/server/szurubooru/search/configs/post_search_config.py
@@ -43,6 +43,10 @@ def _flag_transformer(value: str) -> str:
     return '%' + search_util.enum_transformer(available_values, value) + '%'
 
 
+def _source_transformer(value: str) -> str:
+    return search_util.wildcard_transformer('*' + value + '*')
+
+
 def _create_score_filter(score: int) -> Filter:
     def wrapper(
             query: SaQuery,
@@ -232,7 +236,8 @@ class PostSearchConfig(BaseSearchConfig):
 
             (
                 ['source'],
-                search_util.create_str_filter(model.Post.source)
+                search_util.create_str_filter(
+                    model.Post.source, _source_transformer)
             ),
 
             (

--- a/server/szurubooru/search/configs/post_search_config.py
+++ b/server/szurubooru/search/configs/post_search_config.py
@@ -231,6 +231,11 @@ class PostSearchConfig(BaseSearchConfig):
             ),
 
             (
+                ['source'],
+                search_util.create_str_filter(model.Post.source)
+            ),
+
+            (
                 ['tag-count'],
                 search_util.create_num_filter(model.Post.tag_count)
             ),


### PR DESCRIPTION
Allows searching for posts by source URL.

You can use either something like `source:twitter` to find all all twitter related posts or `source:twitter.com/some-specific-url` for specific URL queries.