### PR TITLE
Added feature / changed bevavior: Button to randomize search results

### DIFF
--- a/client/html/posts_header.tpl
+++ b/client/html/posts_header.tpl
@@ -4,8 +4,9 @@
         %><wbr/><%
         %><input class='mousetrap' type='submit' value='Search'/><%
         %><wbr/><%
-        %><button id="random-button" style="padding:0.2em; margin-right:0.25em; margin-bottom:0.25em;"><i class="fa fa-random"></button><%
-        %><wbr/><%
+        %><button id="random-button" style="padding:0.2em; margin-right:0.25em; margin-bottom:0.25em;"><%
+            %><i class="fa fa-random" style="vertical-align: middle"><%
+                %></button><%
         %><% if (ctx.enableSafety) { %><%
             %><input data-safety=safe type='button' class='mousetrap safety safety-safe <%- ctx.settings.listPosts.safe ? '' : 'disabled' %>'/><%
             %><input data-safety=sketchy type='button' class='mousetrap safety safety-sketchy <%- ctx.settings.listPosts.sketchy ? '' : 'disabled' %>'/><%

--- a/client/html/posts_header.tpl
+++ b/client/html/posts_header.tpl
@@ -4,6 +4,8 @@
         %><wbr/><%
         %><input class='mousetrap' type='submit' value='Search'/><%
         %><wbr/><%
+        %><button id="random-button" style="padding:0.2em; margin-right:0.25em; margin-bottom:0.25em;"><i class="fa fa-random"></button><%
+        %><wbr/><%
         %><% if (ctx.enableSafety) { %><%
             %><input data-safety=safe type='button' class='mousetrap safety safety-safe <%- ctx.settings.listPosts.safe ? '' : 'disabled' %>'/><%
             %><input data-safety=sketchy type='button' class='mousetrap safety safety-sketchy <%- ctx.settings.listPosts.sketchy ? '' : 'disabled' %>'/><%

--- a/client/js/models/post_list.js
+++ b/client/js/models/post_list.js
@@ -17,6 +17,10 @@ class PostList extends AbstractList {
     }
 
     static search(text, offset, limit, fields) {
+        //For queries with random sorting, bypass cache by appending random number
+        let cache = text.includes('sort:random')
+            ? Math.round(Math.random() * 1000)
+            : 0;
         return api.get(
                 uri.formatApiLink(
                     'posts', {
@@ -24,6 +28,7 @@ class PostList extends AbstractList {
                         offset: offset,
                         limit: limit,
                         fields: fields.join(','),
+                        cache: cache,
                     }))
             .then(response => {
                 return Promise.resolve(Object.assign(

--- a/client/js/views/posts_header_view.js
+++ b/client/js/views/posts_header_view.js
@@ -248,10 +248,9 @@ class PostsHeaderView extends events.EventTarget {
         this._navigate();
     }
     _evtRandomButtonClick(e) {
+        e.preventDefault();
         if (!this._queryInputNode.value.includes('sort:random')) {
             this._queryInputNode.value += ' sort:random';
-        } else {
-            location.reload();
         }
         this._navigate();
     }

--- a/client/js/views/posts_header_view.js
+++ b/client/js/views/posts_header_view.js
@@ -145,6 +145,7 @@ class PostsHeaderView extends events.EventTarget {
                 'click', e => this._evtSafetyButtonClick(e));
         }
         this._formNode.addEventListener('submit', e => this._evtFormSubmit(e));
+        this._randomButtonNode.addEventListener('click', e => this._evtRandomButtonClick(e));
 
         this._bulkEditors = [];
         if (this._bulkEditTagsNode) {
@@ -189,6 +190,10 @@ class PostsHeaderView extends events.EventTarget {
 
     get _queryInputNode() {
         return this._hostNode.querySelector('form [name=search-text]');
+    }
+
+    get _randomButtonNode() {
+        return this._hostNode.querySelector('#random-button');
     }
 
     get _bulkEditTagsNode() {
@@ -240,6 +245,14 @@ class PostsHeaderView extends events.EventTarget {
 
     _evtFormSubmit(e) {
         e.preventDefault();
+        this._navigate();
+    }
+    _evtRandomButtonClick(e) {
+        if (!this._queryInputNode.value.includes('sort:random')) {
+            this._queryInputNode.value += ' sort:random';
+        } else {
+            location.reload();
+        }
         this._navigate();
     }
 

--- a/server/szurubooru/search/executor.py
+++ b/server/szurubooru/search/executor.py
@@ -94,7 +94,7 @@ class Executor:
                 disable_eager_loads = True
 
         key = (id(self.config), hash(search_query), offset, limit)
-        if cache.has(key):
+        if not disable_eager_loads and cache.has(key):
             return cache.get(key)
 
         filter_query = self.config.create_filter_query(disable_eager_loads)


### PR DESCRIPTION
I'm using szurubooru as a sort of a personal image gallery. When looking at images, I like to shuffle them around. Currently in szurubooru the option `sort:random` shuffles only once and then returnes a cached result (from what I understood, it's actually cached both on the client and on the server). I suspect this was done for a good reason, but it doesn't work for me, so I changed it:
1. Changed client and server so that the search queries with `sort:random` are never cached, both on client and server.
2. Added a little button to randomize the current query. Here's what it looks like:
![image](https://user-images.githubusercontent.com/3252331/55749061-4f997100-5a6a-11e9-8d7e-737f0d8082b7.png)

I'm not very familiar with this project yet, nor with its stack of technologies, especially JS. Constructive criticism is super welcome.