### PR TITLE
Fix issue with tags which contain slashes

### DIFF
--- a/INSTALL-OLD.md
+++ b/INSTALL-OLD.md
@@ -211,6 +211,7 @@ server {
 
     DocumentRoot "/srv/www/booru/client/public"
     FallbackResource /index.htm
+    AllowEncodedSlashes On
 </VirtualHost>
 ```
 


### PR DESCRIPTION
Apache wouldn't forward api calls which contain encoded slashes (%2F), which caused the api calls to tags with slashes (e.g. 'te/st') to fail with a 404 not found.

Nginx didn't have this problem, so nothing is changed there.

See:
- https://httpd.apache.org/docs/2.4/mod/core.html#AllowEncodedSlashes
- https://serverfault.com/questions/715242/encode-url-wihthin-url-apache-mod-proxy-proxypass/715902#715902