### PR TITLE
Add 'domain' and 'smtp from' config entries

### DIFF
--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -3,6 +3,8 @@
 
 # shown in the website title and on the front page
 name: szurubooru
+# full url to the homepage of this szurubooru site, with no trailing slash
+domain: http://example.com
 # user agent name used to download files from the web on behalf of the api users
 user_agent:
 # used to salt the users' password hashes
@@ -32,7 +34,9 @@ smtp:
     port: # example: 25
     user: # example: bot
     pass: # example: groovy123
-    # host can be left empty, in which case it is recommended to fill contactEmail.
+    from: # example: noreply@example.com
+    # if host is left empty the password reset feature will be disabled, in which case it is
+    # recommended to fill contactEmail so that users know who to contact when they want to reset their password
 
 contact_email: # example: bob@example.com. Meant for manual password reset procedures
 

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -4,7 +4,7 @@
 # shown in the website title and on the front page
 name: szurubooru
 # full url to the homepage of this szurubooru site, with no trailing slash
-domain: http://example.com
+domain: # example: http://example.com
 # user agent name used to download files from the web on behalf of the api users
 user_agent:
 # used to salt the users' password hashes

--- a/server/szurubooru/api/password_reset_api.py
+++ b/server/szurubooru/api/password_reset_api.py
@@ -22,14 +22,18 @@ def start_password_reset(
                 user_name))
     token = auth.generate_authentication_token(user)
 
-    if 'HTTP_ORIGIN' in ctx.env:
+    if config.config['domain']:
+        url = config.config['domain']
+    elif 'HTTP_ORIGIN' in ctx.env:
         url = ctx.env['HTTP_ORIGIN'].rstrip('/')
+    elif 'HTTP_REFERER' in ctx.env:
+        url = ctx.env['HTTP_REFERER'].rstrip('/')
     else:
         url = ''
     url += '/password-reset/%s:%s' % (user.name, token)
 
     mailer.send_mail(
-        'noreply@%s' % config.config['name'],
+        config.config['smtp']['from'],
         user.email,
         MAIL_SUBJECT.format(name=config.config['name']),
         MAIL_BODY.format(name=config.config['name'], url=url))


### PR DESCRIPTION
Fixes #193 and #256

This however requires users to manually set the domain and no-reply address in the config.yaml.
The `domain` field currently is optional, but it would probably be better to make it required and not fall back to HTTP_ORIGIN and HTTP_REFERER, which might be inaccurate or not set (especially behind reverse proxies and the like). 

The `smtp:from` field is required, the server will crash without it set.

This also should break any docker configs that currently exist (though I haven't looked at those).