### PR TITLE
docker: set ulimits for elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,10 @@ services:
       ES_JAVA_OPTS: -Xms512m -Xmx512m
     volumes:
       - index:/usr/share/elasticsearch/data
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 
 volumes:
   index: # Scratch space for ElasticSearch index, will be rebuilt if lost


### PR DESCRIPTION
this sets the ulimits for elasticsearch to the recommended value of 65536 to avoid errors on startup.