### PR TITLE
client/tag_categories: load tag_categories after (attempted) login

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -28,7 +28,6 @@ router.enter(
 
 const tags = require('./tags.js');
 const api = require('./api.js');
-tags.refreshCategoryColorMap(); // we don't care about errors
 
 api.fetchConfig().then(() => {
     // register controller routes
@@ -61,6 +60,7 @@ api.fetchConfig().then(() => {
     window.alert('Could not fetch basic configuration from server');
 }).then(() => {
     api.loginFromCookies().then(() => {
+            tags.refreshCategoryColorMap();
             router.start();
         }, error => {
             if (window.location.href.indexOf('login') !== -1) {


### PR DESCRIPTION
Fixes #262 (as far as I could test at least)

What was wrong:
The client called `refreshCategoryColorMap()` before logging in.

The server received the request before `ctx.user` was set, causing `verify_privilege(ctx.user, 'tag_categories:create')` to be called with the anonymous user, and understandably threw an error when the privilege required something higher than 'anonymous'.

Now it calls `refreshCategoryColorMap()` after logging in, after which it calls `verify_privilege()` on the server with the correct `ctx.user`.