### PR TITLE
client/auth: call tags.refreshCategoryColorMap() after login

### DIFF
--- a/client/js/controllers/auth_controller.js
+++ b/client/js/controllers/auth_controller.js
@@ -2,6 +2,7 @@
 
 const router = require('../router.js');
 const api = require('../api.js');
+const tags = require('../tags.js');
 const uri = require('../util/uri.js');
 const topNavigation = require('../models/top_navigation.js');
 const LoginView = require('../views/login_view.js');
@@ -24,6 +25,8 @@ class LoginController {
             .then(() => {
                 const ctx = router.show(uri.formatClientLink());
                 ctx.controller.showSuccess('Logged in');
+                // reload tag category color map, this is required when `tag_categories:list` has a permission other than anonymous
+                tags.refreshCategoryColorMap();
             }, error => {
                 this._loginView.showError(error.message);
                 this._loginView.enableForm();


### PR DESCRIPTION
When the tag category list permission is not anonymous the category colors fail to load if you are not logged in, and because the page doesn't reload (SPA) the tag colors are still broken after logging in. Manually calling refreshCategoryColorMap after logging in solves this issue.

Should fix last issue discussed in #269 