### PR TITLE
server/info: report correct size when filesystem is missing files

### DIFF
--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -22,7 +22,7 @@ def _get_disk_usage() -> int:
             file_path = os.path.join(dir_path, file_name)
             try:
                 total_size += os.path.getsize(file_path)
-            except:
+            except FileNotFoundError:
                 pass
     _cache_time = now
     _cache_result = total_size

--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -20,7 +20,10 @@ def _get_disk_usage() -> int:
     for dir_path, _, file_names in os.walk(config.config['data_dir']):
         for file_name in file_names:
             file_path = os.path.join(dir_path, file_name)
-            total_size += os.path.getsize(file_path)
+            try:
+                total_size += os.path.getsize(file_path)
+            except:
+                pass
     _cache_time = now
     _cache_result = total_size
     return total_size


### PR DESCRIPTION
In case the data directory has missing files (e.g when accidentally deleted from disk - idk who would be this dumb) szurubooru errors as soon as you open the web page (because it calls /api/info which tries to calculate the total_size). This fixes that by just ignoring deleted files.