### PR TITLE
client/login: always store login cookie as 'auth'

### DIFF
--- a/client/js/api.js
+++ b/client/js/api.js
@@ -9,18 +9,6 @@ const uri = require('./util/uri.js');
 let fileTokens = {};
 let remoteConfig = null;
 
-function getCookieName() {
-    const bases = document.getElementsByTagName('base');
-    if (bases.length) {
-        let baseHref = bases[0].href;
-        baseHref = baseHref.replace('/', '');
-        return 'szuru-' + baseHref;
-    } else {
-        return 'szuru';
-    }
-}
-const cookieName = getCookieName();
-
 class Api extends events.EventTarget {
     constructor() {
         super();
@@ -138,7 +126,7 @@ class Api extends events.EventTarget {
     }
 
     loginFromCookies() {
-        const auth = cookies.getJSON(cookieName);
+        const auth = cookies.getJSON('auth');
         return auth && auth.user && auth.token ?
             this.loginWithToken(auth.user, auth.token, true) :
             Promise.resolve();
@@ -181,7 +169,7 @@ class Api extends events.EventTarget {
             this.post('/user-token/' + userName, userTokenRequest)
                 .then(response => {
                     cookies.set(
-                        cookieName,
+                        'auth',
                         {'user': userName, 'token': response.token},
                         options);
                     this.userName = userName;


### PR DESCRIPTION
I don't know why the decision was made to use a calculated name for the cookie, and I haven't fully looked at the complete login flow. But this seems to at least fix #268. It might break something (as I don't fully understand the login flow) but everything seems to work fine.