### PR TITLE
client/posts: remember offset when opening/closing bulk editor

### DIFF
--- a/client/js/views/posts_header_view.js
+++ b/client/js/views/posts_header_view.js
@@ -248,7 +248,7 @@ class PostsHeaderView extends events.EventTarget {
         let parameters = {query: this._queryInputNode.value};
         
         // convert falsy values to an empty string "" so that we can correctly compare with the current query
-        var prevQuery = this._ctx.parameters.query ? this._ctx.parameters.query : "";
+        const prevQuery = this._ctx.parameters.query ? this._ctx.parameters.query : "";
         parameters.offset = parameters.query === prevQuery ? this._ctx.parameters.offset : 0;
         if (this._bulkTagEditor && this._bulkTagEditor.opened) {
             parameters.tag = this._bulkTagEditor.value;

--- a/client/js/views/posts_header_view.js
+++ b/client/js/views/posts_header_view.js
@@ -246,8 +246,10 @@ class PostsHeaderView extends events.EventTarget {
     _navigate() {
         this._autoCompleteControl.hide();
         let parameters = {query: this._queryInputNode.value};
-        parameters.offset = parameters.query === this._ctx.parameters.query ?
-            this._ctx.parameters.offset : 0;
+        
+        // convert falsy values to an empty string "" so that we can correctly compare with the current query
+        var prevQuery = this._ctx.parameters.query ? this._ctx.parameters.query : "";
+        parameters.offset = parameters.query === prevQuery ? this._ctx.parameters.offset : 0;
         if (this._bulkTagEditor && this._bulkTagEditor.opened) {
             parameters.tag = this._bulkTagEditor.value;
             this._bulkTagEditor.blur();


### PR DESCRIPTION
Fixes #274

This does remove the `parameters.query === this._ctx.parameters.query` logic, but I couldn't figure out what it was meant to do? That said, if you want to keep it I could add it back.