### PR TITLE
detect ftypiso5 as mp4 mime type

### DIFF
--- a/server/szurubooru/func/mime.py
+++ b/server/szurubooru/func/mime.py
@@ -24,7 +24,7 @@ def get_mime_type(content: bytes) -> str:
     if content[0:4] == b'\x1A\x45\xDF\xA3':
         return 'video/webm'
 
-    if content[4:12] in (b'ftypisom', b'ftypmp42'):
+    if content[4:12] in (b'ftypisom', b'ftypiso5', b'ftypmp42'):
         return 'video/mp4'
 
     return 'application/octet-stream'


### PR DESCRIPTION
Some videos weren't detected as mp4.

Example:
http://paste.c-net.org/ComedianTangle

Relevant part of the mimetype info:
`Codec ID                                 : iso5 (avc1/iso5/dsms/msix/dash)
`
