### PR TITLE
Migrate Elasticsearch functionality into Postgres

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -36,45 +36,31 @@ and Docker Compose (version 1.6.0 or greater) already installed.
 
 ### Running the Application
 
-1. Configurations for ElasticSearch:
+Download containers:
+```console
+user@host:szuru$ docker-compose pull
+```
 
-    You may need to raise the `vm.max_map_count`
-    parameter to at least `262144` in order for the
-    ElasticSearch container to function. Instructions
-    on how to do so are provided
-    [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode).
+For first run, it is recommended to start the database separately:
+```console
+user@host:szuru$ docker-compose up -d sql
+```
 
-2. Running the application
+To start all containers:
+```console
+user@host:szuru$ docker-compose up -d
+```
 
-    Download containers:
-    ```console
-    user@host:szuru$ docker-compose pull
-    ```
+To view/monitor the application logs:
+```console
+user@host:szuru$ docker-compose logs -f
+# (CTRL+C to exit)
+```
 
-    For first run, it is reccomended to start the databases seperately:
-    ```console
-    user@host:szuru$ docker-compose up -d elasticsearch
-    user@host:szuru$ docker-compose up -d sql
-    ```
-    Then wait approx. 2 minutes before starting all containers.
-    This gives time for the databases to initalize their storage
-    structure.
-
-    To start all containers:
-    ```console
-    user@host:szuru$ docker-compose up -d
-    ```
-
-    To view/monitor the application logs:
-    ```console
-    user@host:szuru$ docker-compose logs -f
-    # (CTRL+C to exit)
-    ```
-
-    To stop all containers:
-    ```console
-    user@host:szuru$ docker-compose down
-    ```
+To stop all containers:
+```console
+user@host:szuru$ docker-compose down
+```
 
 ### Additional Features
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,32 +5,26 @@
 version: '2'
 
 services:
+
   server:
     image: szurubooru/server:latest
     depends_on:
       - sql
-      - elasticsearch
     environment:
-      ## These should be the names of the dependent containers listed above,
+      ## These should be the names of the dependent containers listed below,
       ## or FQDNs/IP addresses if these services are running outside of Docker
       POSTGRES_HOST: sql
-      ESEARCH_HOST: elasticsearch
       ## Credentials for database:
       POSTGRES_USER:
       POSTGRES_PASSWORD:
       ## Commented Values are Default:
       #POSTGRES_DB: defaults to same as POSTGRES_USER
       #POSTGRES_PORT: 5432
-      #ESEARCH_PORT: 9200
-      #ESEARCH_INDEX: szurubooru
-      #ESEARCH_PASSWORD: (empty by default, set if you are using an external
-      #                  source for elasticsearch and want to use HTTP basic
-      #                  authentication for security)
-      #ESEARCH_USER: szurubooru (only used if password is set)
       #LOG_SQL: 0 (1 for verbose SQL logs)
     volumes:
       - "${MOUNT_DATA}:/data"
       - "./server/config.yaml:/opt/app/config.yaml"
+
   client:
     image: szurubooru/client:latest
     depends_on:
@@ -42,6 +36,7 @@ services:
       - "${MOUNT_DATA}:/data:ro"
     ports:
       - "${PORT}:80"
+
   sql:
     image: postgres:11-alpine
     restart: unless-stopped
@@ -50,20 +45,3 @@ services:
       POSTGRES_PASSWORD:
     volumes:
       - "${MOUNT_SQL}:/var/lib/postgresql/data"
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.1
-    environment:
-      ## Specifies the Java heap size used
-      ## Read
-      ##  https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
-      ## for more info
-      ES_JAVA_OPTS: -Xms512m -Xmx512m
-    volumes:
-      - index:/usr/share/elasticsearch/data
-    ulimits:
-      nofile:
-        soft: 65536
-        hard: 65536
-
-volumes:
-  index: # Scratch space for ElasticSearch index, will be rebuilt if lost

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,8 +21,6 @@ RUN \
     pip3 install --no-cache-dir --disable-pip-version-check \
         alembic \
         "coloredlogs==5.0" \
-        "elasticsearch>=5.0.0,<7.0.0" \
-        "elasticsearch-dsl>=5.0.0,<7.0.0" \
     && exit 0
 
 ARG PUID=1000

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -144,9 +144,3 @@ privileges:
 ## usage: schema://user:password@host:port/database_name
 ## example: postgres://szuru:dog@localhost:5432/szuru_test
 #database:
-#elasticsearch: # used for reverse image search
-#    host: localhost
-#    port: 9200
-#    index: szurubooru
-#    user: szurubooru
-#    pass:

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -21,10 +21,14 @@ thumbnails:
     post_width: 300
     post_height: 300
 
+# automatically convert animated GIF uploads to video formats
 convert:
    gif:
      to_webm: false
      to_mp4: false
+
+# allow posts to be uploaded even if some image processing errors occur
+allow_broken_uploads: false
 
 # used to send password reset e-mails
 smtp:

--- a/server/hooks/test
+++ b/server/hooks/test
@@ -23,8 +23,7 @@ RUN apk --no-cache add \
 USER app
 ENV POSTGRES_HOST=x \
     POSTGRES_USER=x \
-    POSTGRES_PASSWORD=x \
-    ESEARCH_HOST=x
+    POSTGRES_PASSWORD=x
 CMD ["pytest", "szurubooru/", \
 	"--cov-report=term-missing", "--cov=szurubooru", "--tb=short"]
 EOF

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,8 +3,6 @@ pyyaml>=3.11
 psycopg2-binary>=2.6.1
 SQLAlchemy>=1.0.12
 coloredlogs==5.0
-elasticsearch>=5.0.0,<7.0.0
-elasticsearch-dsl>=5.0.0,<7.0.0
 certifi>=2017.11.5
 numpy>=1.8.2
 pillow>=4.3.0

--- a/server/szurubooru/api/post_api.py
+++ b/server/szurubooru/api/post_api.py
@@ -262,9 +262,9 @@ def get_posts_by_image(
         'similarPosts':
             [
                 {
-                    'distance': lookalike.distance,
-                    'post': _serialize_post(ctx, lookalike.post),
+                    'distance': distance,
+                    'post': _serialize_post(ctx, post),
                 }
-                for lookalike in lookalikes
+                for distance, post in lookalikes
             ],
     }

--- a/server/szurubooru/config.py
+++ b/server/szurubooru/config.py
@@ -21,12 +21,7 @@ def _merge(left: Dict, right: Dict) -> Dict:
 
 
 def _docker_config() -> Dict:
-    for key in [
-            'POSTGRES_USER',
-            'POSTGRES_PASSWORD',
-            'POSTGRES_HOST',
-            'ESEARCH_HOST'
-    ]:
+    for key in ['POSTGRES_USER', 'POSTGRES_PASSWORD', 'POSTGRES_HOST']:
         if not os.getenv(key, False):
             raise errors.ConfigError(f'Environment variable "{key}" not set')
     return {
@@ -40,13 +35,6 @@ def _docker_config() -> Dict:
             'host': os.getenv('POSTGRES_HOST'),
             'port': int(os.getenv('POSTGRES_PORT', 5432)),
             'db': os.getenv('POSTGRES_DB', os.getenv('POSTGRES_USER'))
-        },
-        'elasticsearch': {
-            'host': os.getenv('ESEARCH_HOST'),
-            'port': int(os.getenv('ESEARCH_PORT', 9200)),
-            'index': os.getenv('ESEARCH_INDEX', 'szurubooru'),
-            'user': os.getenv('ESEARCH_USER', os.getenv('ESEARCH_INDEX', 'szurubooru')),
-            'pass': os.getenv('ESEARCH_PASSWORD', False)
         }
     }
 

--- a/server/szurubooru/facade.py
+++ b/server/szurubooru/facade.py
@@ -8,7 +8,7 @@ import coloredlogs
 import sqlalchemy as sa
 import sqlalchemy.orm.exc
 from szurubooru import config, db, errors, rest
-from szurubooru.func import posts, file_uploads, image_hash
+from szurubooru.func import file_uploads
 # pylint: disable=unused-import
 from szurubooru import api, middleware
 
@@ -129,13 +129,7 @@ def create_app() -> Callable[[Any, Any], Any]:
     purge_thread.daemon = True
     purge_thread.start()
 
-    try:
-        image_hash.get_session().cluster.health(
-            wait_for_status='yellow', request_timeout=120)
-        posts.populate_reverse_search()
-        db.session.commit()
-    except errors.ThirdPartyError:
-        pass
+    db.session.commit()
 
     rest.errors.handle(errors.AuthError, _on_auth_error)
     rest.errors.handle(errors.ValidationError, _on_validation_error)

--- a/server/szurubooru/facade.py
+++ b/server/szurubooru/facade.py
@@ -120,7 +120,6 @@ def create_app() -> Callable[[Any, Any], Any]:
     ''' Create a WSGI compatible App object. '''
     validate_config()
     coloredlogs.install(fmt='[%(asctime)-15s] %(name)s %(message)s')
-    logging.getLogger('elasticsearch').disabled = True
     if config.config['debug']:
         logging.getLogger('szurubooru').setLevel(logging.INFO)
     if config.config['show_sql']:

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -513,8 +513,13 @@ def update_all_post_signatures() -> None:
         .order_by(model.Post.post_id.asc())
         .all())
     for post in posts_to_hash:
-        logger.info('Generating hash info for %d', post.post_id)
-        generate_post_signature(post, files.get(get_post_content_path(post)))
+        try:
+            generate_post_signature(
+                post, files.get(get_post_content_path(post)))
+            db.session.commit()
+            logger.info('Hashed Post %d', post.post_id)
+        except Exception as ex:
+            logger.exception(ex)
 
 
 def update_post_content(post: model.Post, content: Optional[bytes]) -> None:

--- a/server/szurubooru/migrations/versions/52d6ea6584b8_generate_post_signature_table.py
+++ b/server/szurubooru/migrations/versions/52d6ea6584b8_generate_post_signature_table.py
@@ -1,0 +1,30 @@
+'''
+Generate post signature table
+
+Revision ID: 52d6ea6584b8
+Created at: 2020-03-07 17:03:40.193512
+'''
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = '52d6ea6584b8'
+down_revision = '3c1f0316fa7f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    ArrayType = sa.dialects.postgresql.ARRAY(sa.Integer, dimensions=1)
+    op.create_table(
+        'post_signature',
+        sa.Column('post_id', sa.Integer(), nullable=False),
+        sa.Column('signature', sa.LargeBinary(), nullable=False),
+        sa.Column('words', ArrayType, nullable=False),
+        sa.ForeignKeyConstraint(['post_id'], ['post.id']),
+        sa.PrimaryKeyConstraint('post_id'))
+
+
+def downgrade():
+    op.drop_table('post_signature')

--- a/server/szurubooru/model/__init__.py
+++ b/server/szurubooru/model/__init__.py
@@ -9,7 +9,8 @@ from szurubooru.model.post import (
     PostFavorite,
     PostScore,
     PostNote,
-    PostFeature)
+    PostFeature,
+    PostSignature)
 from szurubooru.model.comment import Comment, CommentScore
 from szurubooru.model.snapshot import Snapshot
 import szurubooru.model.util

--- a/server/szurubooru/model/post.py
+++ b/server/szurubooru/model/post.py
@@ -143,6 +143,26 @@ class PostTag(Base):
         self.tag_id = tag_id
 
 
+class PostSignature(Base):
+    __tablename__ = 'post_signature'
+
+    post_id = sa.Column(
+        'post_id',
+        sa.Integer,
+        sa.ForeignKey('post.id'),
+        primary_key=True,
+        nullable=False,
+        index=True)
+    signature = sa.Column('signature', sa.LargeBinary, nullable=False)
+    words = sa.Column(
+        'words',
+        sa.dialects.postgresql.ARRAY(sa.Integer, dimensions=1),
+        nullable=False,
+        index=True)
+
+    post = sa.orm.relationship('Post')
+
+
 class Post(Base):
     __tablename__ = 'post'
 
@@ -184,6 +204,11 @@ class Post(Base):
     # foreign tables
     user = sa.orm.relationship('User')
     tags = sa.orm.relationship('Tag', backref='posts', secondary='post_tag')
+    signature = sa.orm.relationship(
+        'PostSignature',
+        uselist=False,
+        cascade='all, delete-orphan',
+        lazy='joined')
     relations = sa.orm.relationship(
         'Post',
         secondary='post_relation',

--- a/server/szurubooru/model/post.py
+++ b/server/szurubooru/model/post.py
@@ -207,7 +207,7 @@ class Post(Base):
     signature = sa.orm.relationship(
         'PostSignature',
         uselist=False,
-        cascade='all, delete-orphan',
+        cascade='all, delete, delete-orphan',
         lazy='joined')
     relations = sa.orm.relationship(
         'Post',

--- a/server/szurubooru/tests/api/test_post_creating.py
+++ b/server/szurubooru/tests/api/test_post_creating.py
@@ -12,6 +12,7 @@ def inject_config(config_injector):
             'posts:create:identified': model.User.RANK_REGULAR,
             'tags:create': model.User.RANK_REGULAR,
         },
+        'allow_broken_uploads': False,
     })
 
 
@@ -250,8 +251,7 @@ def test_omitting_optional_field(
 
 
 def test_errors_not_spending_ids(
-        config_injector, tmpdir, context_factory, read_asset, user_factory,
-        skip_post_hashing):
+        config_injector, tmpdir, context_factory, read_asset, user_factory):
     config_injector({
         'data_dir': str(tmpdir.mkdir('data')),
         'data_url': 'example.com',

--- a/server/szurubooru/tests/api/test_post_updating.py
+++ b/server/szurubooru/tests/api/test_post_updating.py
@@ -19,6 +19,7 @@ def inject_config(config_injector):
             'posts:edit:thumbnail': model.User.RANK_REGULAR,
             'tags:create': model.User.RANK_MODERATOR,
         },
+        'allow_broken_uploads': False,
     })
 
 

--- a/server/szurubooru/tests/conftest.py
+++ b/server/szurubooru/tests/conftest.py
@@ -139,15 +139,8 @@ def tag_factory():
     return factory
 
 
-@pytest.yield_fixture
-def skip_post_hashing():
-    with patch('szurubooru.func.image_hash.add_image'), \
-            patch('szurubooru.func.image_hash.delete_image'):
-        yield
-
-
 @pytest.fixture
-def post_factory(skip_post_hashing):
+def post_factory():
     # pylint: disable=invalid-name
     def factory(
             id=None,

--- a/server/szurubooru/tests/model/test_post.py
+++ b/server/szurubooru/tests/model/test_post.py
@@ -81,7 +81,11 @@ def test_cascade_deletions(
     note.post = post
     note.polygon = ''
     note.text = ''
-    db.session.add_all([score, favorite, feature, note])
+    signature = model.PostSignature()
+    signature.post = post
+    signature.signature = b'testvalue'
+    signature.words = list(range(50))
+    db.session.add_all([score, favorite, feature, note, signature])
     db.session.flush()
 
     post.user = user
@@ -107,6 +111,7 @@ def test_cascade_deletions(
     assert db.session.query(model.PostNote).count() == 1
     assert db.session.query(model.PostFeature).count() == 1
     assert db.session.query(model.PostFavorite).count() == 1
+    assert db.session.query(model.PostSignature).count() == 1
     assert db.session.query(model.Comment).count() == 1
 
     db.session.delete(post)
@@ -122,6 +127,7 @@ def test_cascade_deletions(
     assert db.session.query(model.PostNote).count() == 0
     assert db.session.query(model.PostFeature).count() == 0
     assert db.session.query(model.PostFavorite).count() == 0
+    assert db.session.query(model.PostSignature).count() == 0
     assert db.session.query(model.Comment).count() == 0
 
 


### PR DESCRIPTION
Hey, @rr- , I would like you to review this before I merge it in.

This basically moves the reverse image search functionality that relied on Elasticsearch into Postgres, which was surprisingly easy. I test ran it on a copy of my personal instance (with about 4k images) and it seems to have similar performance to Elasticsearch as well, while being much more lightweight.

Only thing that feels a bit hacky to me is that I had to write raw SQL for the image search query. It seems like SQLAlchemy doesn't have a full implementation of Postgres' `unnest` function:
https://groups.google.com/forum/#!msg/sqlalchemy/thc9rla91gU/uFpXTAFKAwAJ