### PR TITLE
server/func/tags: allow tags to have longer names

### DIFF
--- a/server/szurubooru/migrations/versions/1e280b5d5df1_longer_tag_names.py
+++ b/server/szurubooru/migrations/versions/1e280b5d5df1_longer_tag_names.py
@@ -1,0 +1,43 @@
+'''
+Longer tag names
+
+Revision ID: 1e280b5d5df1
+Created at: 2020-03-15 18:57:12.901148
+'''
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = '1e280b5d5df1'
+down_revision = '52d6ea6584b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        'tag_name', 'name',
+        type_=sa.Unicode(128),
+        existing_type=sa.Unicode(64),
+        existing_nullable=False)
+
+    op.alter_column(
+        'snapshot', 'resource_name',
+        type_=sa.Unicode(128),
+        existing_type=sa.Unicode(64),
+        existing_nullable=False)
+
+
+def downgrade():
+    op.alter_column(
+        'tag_name', 'name',
+        type_=sa.Unicode(64),
+        existing_type=sa.Unicode(128),
+        existing_nullable=False)
+
+    op.alter_column(
+        'snapshot', 'resource_name',
+        type_=sa.Unicode(64),
+        existing_type=sa.Unicode(128),
+        existing_nullable=False)

--- a/server/szurubooru/model/snapshot.py
+++ b/server/szurubooru/model/snapshot.py
@@ -18,7 +18,7 @@ class Snapshot(Base):
     resource_pkey = sa.Column(
         'resource_pkey', sa.Integer, nullable=False, index=True)
     resource_name = sa.Column(
-        'resource_name', sa.Unicode(64), nullable=False)
+        'resource_name', sa.Unicode(128), nullable=False)
     user_id = sa.Column(
         'user_id',
         sa.Integer,

--- a/server/szurubooru/model/tag.py
+++ b/server/szurubooru/model/tag.py
@@ -59,7 +59,7 @@ class TagName(Base):
         sa.ForeignKey('tag.id'),
         nullable=False,
         index=True)
-    name = sa.Column('name', sa.Unicode(64), nullable=False, unique=True)
+    name = sa.Column('name', sa.Unicode(128), nullable=False, unique=True)
     order = sa.Column('ord', sa.Integer, nullable=False, index=True)
 
     def __init__(self, name: str, order: int) -> None:


### PR DESCRIPTION
Because some series are called itai_no_wa_iya_nano_de_bougyoryoku_ni_kyokufuri_shitai_to_omoimasu.
128 seemed like the most logical number after 64. I guess 80 or something like that would suffice, but then we might have another PR in 4 months. Space-wise it doesn't actually matter.