### PR TITLE
Allow for fetching post content with youtube-dl

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ scrubbing](http://sjp.pwn.pl/sjp/;2527372). It is pronounced as *shoorubooru*.
 ## Features
 
 - Post content: images (JPG, PNG, GIF, animated GIF), videos (MP4, WEBM), Flash animations
+- Ability to retrieve web video content using [youtube-dl](https://github.com/ytdl-org/youtube-dl)
 - Post comments
 - Post notes / annotations, including arbitrary polygons
 - Rich JSON REST API ([see documentation](doc/API.md))

--- a/client/html/post_upload_row.tpl
+++ b/client/html/post_upload_row.tpl
@@ -64,16 +64,6 @@
                         }) %>
                     </div>
                 <% } %>
-
-                <% if (['video'].includes(ctx.uploadable.type)) { %>
-                    <div class='loop-video'>
-                        <%= ctx.makeCheckbox({
-                            text: 'Loop video',
-                            name: 'loop-video',
-                            checked: ctx.uploadable.flags.includes('loop'),
-                        }) %>
-                    </div>
-                <% } %>
             </div>
 
             <div class='messages'></div>

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -49,12 +49,6 @@ class Uploadable extends events.EventTarget {
     get name() {
         throw new Error('Not implemented');
     }
-
-    _initComplete() {
-        if (['video'].includes(this.type)) {
-            this.flags.push('loop');
-        }
-    }
 }
 
 class File extends Uploadable {
@@ -74,7 +68,6 @@ class File extends Uploadable {
                     new CustomEvent('finish', {detail: {uploadable: this}}));
             });
         }
-        this._initComplete();
     }
 
     destroy() {
@@ -105,7 +98,6 @@ class Url extends Uploadable {
         super();
         this.url = url;
         this.dispatchEvent(new CustomEvent('finish'));
-        this._initComplete();
     }
 
     get mimeType() {
@@ -288,11 +280,6 @@ class PostUploadView extends events.EventTarget {
         const anonymousNode = rowNode.querySelector('.anonymous input:checked');
         if (anonymousNode) {
             uploadable.anonymous = true;
-        }
-
-        uploadable.flags = [];
-        if (rowNode.querySelector('.loop-video input:checked')) {
-            uploadable.flags.push('loop');
         }
 
         uploadable.tags = [];

--- a/doc/API.md
+++ b/doc/API.md
@@ -843,12 +843,13 @@ data.
     automatically created. Tags created automatically have no implications, no
     suggestions, one name and their category is set to the first tag category
     found. Safety must be any of `"safe"`, `"sketchy"` or `"unsafe"`. Relations
-    must contain valid post IDs. `<flag>` currently can be only `"loop"` to
-    enable looping for video posts. Sending empty `thumbnail` will cause the
-    post to use default thumbnail. If `anonymous` is set to truthy value, the
-    uploader name won't be recorded (privilege verification still applies; it's
-    possible to disallow anonymous uploads completely from config.) For details
-    how to pass `content` and `thumbnail`, see [file uploads](#file-uploads).
+    must contain valid post IDs. If `<flag>` is omitted, they will be defined
+    by default (`"loop"` will be set for all video posts, and `"sound"` will be
+    auto-detected). Sending empty `thumbnail` will cause the post to use default
+    thumbnail. If `anonymous` is set to truthy value, the uploader name won't be
+    recorded (privilege verification still applies; it's possible to disallow
+    anonymous uploads completely from config.) For details on how to pass `content`
+    and `thumbnail`, see [file uploads](#file-uploads).
 
 ## Updating post
 - **Request**
@@ -892,9 +893,9 @@ data.
     automatically created. Tags created automatically have no implications, no
     suggestions, one name and their category is set to the first tag category
     found. Safety must be any of `"safe"`, `"sketchy"` or `"unsafe"`. Relations
-    must contain valid post IDs. `<flag>` currently can be only `"loop"` to
-    enable looping for video posts. Sending empty `thumbnail` will reset the
-    post thumbnail to default. For details how to pass `content` and
+    must contain valid post IDs. `<flag>` can be either `"loop"` to enable looping
+    for video posts or `"sound"` to indicate sound. Sending empty `thumbnail` will
+    reset the post thumbnail to default. For details how to pass `content` and
     `thumbnail`, see [file uploads](#file-uploads). All fields except the
     [`version`](#versioning) are optional - update concerns only provided
     fields.

--- a/doc/API.md
+++ b/doc/API.md
@@ -145,7 +145,10 @@ way. The files, however, should be passed as regular fields appended with a
 `Url` suffix. For example, to use `http://example.com/file.jpg` in an API that
 accepts a file named `content`, the client should pass
 `{"contentUrl":"http://example.com/file.jpg"}` as a part of the JSON message
-body.
+body. When creating or updating post content using this method, the server can
+also be configured to employ [youtube-dl](https://github.com/ytdl-org/youtube-dl)
+to download content from popular sites such as youtube, gfycat, etc. Access to
+youtube-dl can be configured with the `'uploads:use_downloader'` permission
 
 Finally, in some cases the user might want to reuse one file between the
 requests to save the bandwidth (for example, reverse search + consecutive

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,6 +21,7 @@ RUN \
     pip3 install --no-cache-dir --disable-pip-version-check \
         alembic \
         "coloredlogs==5.0" \
+        youtube-dl \
     && exit 0
 
 ARG PUID=1000

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -135,6 +135,7 @@ privileges:
     'snapshots:list':               power
 
     'uploads:create':               regular
+    'uploads:use_downloader':       power
 
 ## ONLY SET THESE IF DEPLOYING OUTSIDE OF DOCKER
 #debug: 0 # generate server logs?

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -5,8 +5,6 @@
 name: szurubooru
 # full url to the homepage of this szurubooru site, with no trailing slash
 domain: # example: http://example.com
-# user agent name used to download files from the web on behalf of the api users
-user_agent:
 # used to salt the users' password hashes and generate filenames for static content
 secret: change
 
@@ -20,6 +18,10 @@ thumbnails:
     avatar_height: 300
     post_width: 300
     post_height: 300
+
+# settings used to download files from the web on behalf of the api users
+user_agent:
+max_dl_filesize: 25.0E+6 # maximum filesize limit in bytes
 
 # automatically convert animated GIF uploads to video formats
 convert:

--- a/server/szurubooru/api/post_api.py
+++ b/server/szurubooru/api/post_api.py
@@ -54,7 +54,9 @@ def create_post(
         source = ctx.get_param_as_string('contentUrl', default='')
     relations = ctx.get_param_as_int_list('relations', default=[])
     notes = ctx.get_param_as_list('notes', default=[])
-    flags = ctx.get_param_as_string_list('flags', default=[])
+    flags = ctx.get_param_as_string_list(
+        'flags',
+        default=posts.get_default_flags(content))
 
     post, new_tags = posts.create_post(
         content, tag_names, None if anonymous else ctx.user)
@@ -65,7 +67,6 @@ def create_post(
     posts.update_post_relations(post, relations)
     posts.update_post_notes(post, notes)
     posts.update_post_flags(post, flags)
-    posts.test_sound(post, content)
     if ctx.has_file('thumbnail'):
         posts.update_post_thumbnail(post, ctx.get_file('thumbnail'))
     ctx.session.add(post)

--- a/server/szurubooru/api/upload_api.py
+++ b/server/szurubooru/api/upload_api.py
@@ -7,6 +7,10 @@ from szurubooru.func import auth, file_uploads
 def create_temporary_file(
         ctx: rest.Context, _params: Dict[str, str] = {}) -> rest.Response:
     auth.verify_privilege(ctx.user, 'uploads:create')
-    content = ctx.get_file('content', allow_tokens=False)
+    content = ctx.get_file(
+        'content',
+        allow_tokens=False,
+        use_video_downloader=auth.has_privilege(
+            ctx.user, 'uploads:use_downloader'))
     token = file_uploads.save(content)
     return {'token': token}

--- a/server/szurubooru/errors.py
+++ b/server/szurubooru/errors.py
@@ -56,3 +56,6 @@ class InvalidParameterError(ValidationError):
 
 class ThirdPartyError(BaseError):
     pass
+
+class DownloadTooLargeError(ProcessingError):
+    pass

--- a/server/szurubooru/func/net.py
+++ b/server/szurubooru/func/net.py
@@ -1,9 +1,17 @@
+import logging
 import urllib.request
-from szurubooru import config
-from szurubooru import errors
+import os
+from tempfile import NamedTemporaryFile
+from szurubooru import config, errors
+from szurubooru.func import mime, util
+from youtube_dl import YoutubeDL
+from youtube_dl.utils import YoutubeDLError
 
 
-def download(url: str) -> bytes:
+logger = logging.getLogger(__name__)
+
+
+def download(url: str, use_video_downloader: bool = False) -> bytes:
     assert url
     request = urllib.request.Request(url)
     if config.config['user_agent']:
@@ -11,6 +19,32 @@ def download(url: str) -> bytes:
     request.add_header('Referer', url)
     try:
         with urllib.request.urlopen(request) as handle:
-            return handle.read()
+            content = handle.read()
     except Exception as ex:
         raise errors.ProcessingError('Error downloading %s (%s)' % (url, ex))
+    if (use_video_downloader and
+            mime.get_mime_type(content) == 'application/octet-stream'):
+        return _youtube_dl_wrapper(url)
+    return content
+
+
+def _youtube_dl_wrapper(url: str) -> bytes:
+    options = {
+        'quiet': True,
+        'format': 'webm/mp4',
+        'logger': logger,
+        'noplaylist': True,
+        'outtmpl': os.path.join(
+            config.config['data_dir'],
+            'temporary-uploads',
+            'youtubedl-' + util.get_sha1(url)[0:8] + '.%(ext)s'),
+    }
+    with YoutubeDL(options) as ydl:
+        try:
+            ydl_info = ydl.extract_info(url, download=True)
+            ydl_filename = ydl.prepare_filename(ydl_info)
+        except YoutubeDLError as ex:
+            raise errors.ThirdPartyError(
+                'Error downloading video %s (%s)' % (url, ex))
+    with open(ydl_filename, 'rb') as f:
+        return f.read()

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -467,15 +467,14 @@ def generate_alternate_formats(post: model.Post, content: bytes) \
     return new_posts
 
 
-def test_sound(post: model.Post, content: bytes) -> None:
-    assert post
+def get_default_flags(content: bytes) -> List[str]:
     assert content
+    ret = []
     if mime.is_video(mime.get_mime_type(content)):
+        ret.append(model.Post.FLAG_LOOP)
         if images.Image(content).check_for_sound():
-            flags = post.flags
-            if model.Post.FLAG_SOUND not in flags:
-                flags.append(model.Post.FLAG_SOUND)
-            update_post_flags(post, flags)
+            ret.append(model.Post.FLAG_SOUND)
+    return ret
 
 
 def purge_post_signature(post: model.Post) -> None:

--- a/server/szurubooru/rest/context.py
+++ b/server/szurubooru/rest/context.py
@@ -46,12 +46,15 @@ class Context:
             self,
             name: str,
             default: Union[object, bytes] = MISSING,
+            use_video_downloader: bool = False,
             allow_tokens: bool = True) -> bytes:
         if name in self._files and self._files[name]:
             return self._files[name]
 
         if name + 'Url' in self._params:
-            return net.download(self._params[name + 'Url'])
+            return net.download(
+                self._params[name + 'Url'],
+                use_video_downloader=use_video_downloader)
 
         if allow_tokens and name + 'Token' in self._params:
             ret = file_uploads.get(self._params[name + 'Token'])

--- a/server/szurubooru/tests/api/test_post_updating.py
+++ b/server/szurubooru/tests/api/test_post_updating.py
@@ -18,6 +18,7 @@ def inject_config(config_injector):
             'posts:edit:flags': model.User.RANK_REGULAR,
             'posts:edit:thumbnail': model.User.RANK_REGULAR,
             'tags:create': model.User.RANK_MODERATOR,
+            'uploads:use_downloader': model.User.RANK_REGULAR,
         },
         'allow_broken_uploads': False,
     })
@@ -97,7 +98,8 @@ def test_uploading_from_url_saves_source(
                 params={'contentUrl': 'example.com', 'version': 1},
                 user=user_factory(rank=model.User.RANK_REGULAR)),
             {'post_id': post.post_id})
-        net.download.assert_called_once_with('example.com')
+        net.download.assert_called_once_with(
+            'example.com', use_video_downloader=True)
         posts.update_post_content.assert_called_once_with(post, b'content')
         posts.update_post_source.assert_called_once_with(post, 'example.com')
 
@@ -121,7 +123,8 @@ def test_uploading_from_url_with_source_specified(
                     'version': 1},
                 user=user_factory(rank=model.User.RANK_REGULAR)),
             {'post_id': post.post_id})
-        net.download.assert_called_once_with('example.com')
+        net.download.assert_called_once_with(
+            'example.com', use_video_downloader=True)
         posts.update_post_content.assert_called_once_with(post, b'content')
         posts.update_post_source.assert_called_once_with(post, 'example2.com')
 

--- a/server/szurubooru/tests/func/test_net.py
+++ b/server/szurubooru/tests/func/test_net.py
@@ -1,4 +1,7 @@
+import pytest
+from szurubooru.errors import ThirdPartyError
 from szurubooru.func import net
+from szurubooru.func.util import get_sha1
 
 
 def test_download(config_injector):
@@ -47,3 +50,26 @@ def test_download(config_injector):
 
     actual_content = net.download(url)
     assert actual_content == expected_content
+
+
+def test_video_download(tmpdir, config_injector):
+    config_injector({
+        'user_agent': None,
+        'data_dir': str(tmpdir.mkdir('data'))
+    })
+    url = 'https://www.youtube.com/watch?v=C0DPdy98e4c'
+    expected_sha1 = '508f89ee85bc6186e18cfaa4f4d0279bcf2418ab'
+
+    actual_content = net.download(url, use_video_downloader=True)
+    assert get_sha1(actual_content) == expected_sha1
+
+
+def test_failed_video_download(tmpdir, config_injector):
+    config_injector({
+        'user_agent': None,
+        'data_dir': str(tmpdir.mkdir('data'))
+    })
+    url = 'http://info.cern.ch/hypertext/WWW/TheProject.html'
+
+    with pytest.raises(ThirdPartyError):
+        net.download(url, use_video_downloader=True)

--- a/server/szurubooru/tests/rest/test_context.py
+++ b/server/szurubooru/tests/rest/test_context.py
@@ -25,7 +25,8 @@ def test_get_file_from_url():
         ctx = rest.Context(
             env={}, method=None, url=None, params={'keyUrl': 'example.com'})
         assert ctx.get_file('key') == b'content'
-        net.download.assert_called_once_with('example.com')
+        net.download.assert_called_once_with(
+            'example.com', use_video_downloader=False)
         with pytest.raises(errors.ValidationError):
             assert ctx.get_file('non-existing')
 


### PR DESCRIPTION
- Allows for video-based posts to be created by using youtube-dl.  Now you can directly pass a URL to a site containing a video file (youtube, gfycat, etc) to generate a video post, instead of having to find a hotlink to the .mp4/.webm file (if one even exists).
- While convenient, there is potential for abuse of this feature, so a new permission "uploads:use_downloader" has been created, defaulting to power users and above.
- Default flag behavior has been changed globally (to partially support this). When using the web interface, the "loop" flag is set by default for all video posts. Users accessing the API directly can circumvent the defaults by ensuring that the `flag` parameter is set in the request.