### PR TITLE
Add optional reCAPTCHA for registration

### DIFF
--- a/client/html/index.htm
+++ b/client/html/index.htm
@@ -22,6 +22,7 @@
     <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-1668x2224.png' media='(min-device-width: 834px) and (max-device-width: 834px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
     <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-2048x2732.png' media='(min-device-width: 1024px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
     <link rel='manifest' href='manifest.json'/>
+    <script src="https://www.google.com/recaptcha/api.js"></script>
 </head>
 <body>
     <div id='top-navigation-holder'></div>

--- a/client/html/user_registration.tpl
+++ b/client/html/user_registration.tpl
@@ -38,8 +38,7 @@
 
         <div class='messages'></div>
         <div class='buttons'>
-            <div id="recaptcha"></div>
-            <br>
+            <% if(ctx.enableRecaptcha) print(`<div id="recaptcha"></div><br>`); %>
             <input type='submit' value='Create an account'/>
         </div>
     </form>

--- a/client/html/user_registration.tpl
+++ b/client/html/user_registration.tpl
@@ -38,6 +38,8 @@
 
         <div class='messages'></div>
         <div class='buttons'>
+            <div id="recaptcha"></div>
+            <br>
             <input type='submit' value='Create an account'/>
         </div>
     </form>

--- a/client/js/api.js
+++ b/client/js/api.js
@@ -108,6 +108,10 @@ class Api extends events.EventTarget {
         return !!remoteConfig.enableSafety;
     }
 
+    recaptchaEnabled() {
+        return !!remoteConfig.enableRecaptcha;
+    }
+
     hasPrivilege(lookup) {
         let minViableRank = null;
         for (let p of Object.keys(remoteConfig.privileges)) {

--- a/client/js/api.js
+++ b/client/js/api.js
@@ -100,6 +100,10 @@ class Api extends events.EventTarget {
         return remoteConfig.contactEmail;
     }
 
+    getRecaptchaSiteKey() {
+        return remoteConfig.recaptchaSiteKey;
+    }
+
     canSendMails() {
         return !!remoteConfig.canSendMails;
     }

--- a/client/js/controllers/user_registration_controller.js
+++ b/client/js/controllers/user_registration_controller.js
@@ -30,7 +30,7 @@ class UserRegistrationController {
         user.email = e.detail.email;
         user.password = e.detail.password;
         const isLoggedIn = api.isLoggedIn();
-        user.save()
+        user.save(e.detail.recaptchaToken)
             .then(() => {
                 if (isLoggedIn) {
                     return Promise.resolve();

--- a/client/js/models/user.js
+++ b/client/js/models/user.js
@@ -107,7 +107,7 @@ class User extends events.EventTarget {
         });
     }
 
-    save() {
+    save(recaptchaToken) {
         const files = [];
         const detail = { version: this._version };
         const transient = this._orig._name;
@@ -131,13 +131,16 @@ class User extends events.EventTarget {
         if (this._password) {
             detail.password = this._password;
         }
+        if (!api.isLoggedIn()) {
+            detail.recaptchaToken = recaptchaToken;
+        }
 
         let promise = this._orig._name
             ? api.put(
-                  uri.formatApiLink("user", this._orig._name),
-                  detail,
-                  files
-              )
+                uri.formatApiLink("user", this._orig._name),
+                detail,
+                files
+            )
             : api.post(uri.formatApiLink("users"), detail, files);
 
         return promise.then((response) => {

--- a/client/js/views/registration_view.js
+++ b/client/js/views/registration_view.js
@@ -5,6 +5,7 @@ const api = require("../api.js");
 const views = require("../util/views.js");
 
 const template = views.getTemplate("user-registration");
+const RECAPTCHA_SITE_KEY = "site key";
 
 class RegistrationView extends events.EventTarget {
     constructor() {
@@ -20,6 +21,13 @@ class RegistrationView extends events.EventTarget {
         views.syncScrollPosition();
         views.decorateValidator(this._formNode);
         this._formNode.addEventListener("submit", (e) => this._evtSubmit(e));
+        this.renderRecaptcha();
+    }
+
+    renderRecaptcha() {
+        grecaptcha.render(this._recaptchaNode, {
+            "sitekey": RECAPTCHA_SITE_KEY
+        });
     }
 
     clearMessages() {
@@ -65,6 +73,10 @@ class RegistrationView extends events.EventTarget {
 
     get _emailFieldNode() {
         return this._formNode.querySelector("[name=email]");
+    }
+
+    get _recaptchaNode() {
+        return this._formNode.querySelector("#recaptcha");
     }
 }
 

--- a/client/js/views/registration_view.js
+++ b/client/js/views/registration_view.js
@@ -10,12 +10,17 @@ const RECAPTCHA_SITE_KEY = "site key";
 class RegistrationView extends events.EventTarget {
     constructor() {
         super();
+
+        // Show the recaptcha only for anonymous users.
+        const showRecaptcha = (!api.isLoggedIn() && api.recaptchaEnabled());
+
         this._hostNode = document.getElementById("content-holder");
         views.replaceContent(
             this._hostNode,
             template({
                 userNamePattern: api.getUserNameRegex(),
                 passwordPattern: api.getPasswordRegex(),
+                enableRecaptcha: showRecaptcha,
             })
         );
         views.syncScrollPosition();
@@ -23,8 +28,7 @@ class RegistrationView extends events.EventTarget {
         this._formNode.addEventListener("submit", (e) => this._evtSubmit(e));
         this.setRecaptchaToken = this.setRecaptchaToken.bind(this);
 
-        // Show the recaptcha for anonymous users.
-        if (!api.isLoggedIn())
+        if (showRecaptcha)
             this.renderRecaptcha();
     }
 
@@ -36,7 +40,6 @@ class RegistrationView extends events.EventTarget {
     }
 
     setRecaptchaToken(token) {
-        console.log("Recaptcha token:", token);
         this.recaptchaToken = token;
     }
 

--- a/client/js/views/registration_view.js
+++ b/client/js/views/registration_view.js
@@ -22,7 +22,10 @@ class RegistrationView extends events.EventTarget {
         views.decorateValidator(this._formNode);
         this._formNode.addEventListener("submit", (e) => this._evtSubmit(e));
         this.setRecaptchaToken = this.setRecaptchaToken.bind(this);
-        this.renderRecaptcha();
+
+        // Show the recaptcha for anonymous users.
+        if (!api.isLoggedIn())
+            this.renderRecaptcha();
     }
 
     renderRecaptcha() {

--- a/client/js/views/registration_view.js
+++ b/client/js/views/registration_view.js
@@ -21,13 +21,20 @@ class RegistrationView extends events.EventTarget {
         views.syncScrollPosition();
         views.decorateValidator(this._formNode);
         this._formNode.addEventListener("submit", (e) => this._evtSubmit(e));
+        this.setRecaptchaToken = this.setRecaptchaToken.bind(this);
         this.renderRecaptcha();
     }
 
     renderRecaptcha() {
         grecaptcha.render(this._recaptchaNode, {
-            "sitekey": RECAPTCHA_SITE_KEY
+            "callback": this.setRecaptchaToken,
+            "sitekey": RECAPTCHA_SITE_KEY,
         });
+    }
+
+    setRecaptchaToken(token) {
+        console.log("Recaptcha token:", token);
+        this.recaptchaToken = token;
     }
 
     clearMessages() {
@@ -54,6 +61,7 @@ class RegistrationView extends events.EventTarget {
                     name: this._userNameFieldNode.value,
                     password: this._passwordFieldNode.value,
                     email: this._emailFieldNode.value,
+                    recaptchaToken: this.recaptchaToken,
                 },
             })
         );

--- a/client/js/views/registration_view.js
+++ b/client/js/views/registration_view.js
@@ -5,7 +5,6 @@ const api = require("../api.js");
 const views = require("../util/views.js");
 
 const template = views.getTemplate("user-registration");
-const RECAPTCHA_SITE_KEY = "site key";
 
 class RegistrationView extends events.EventTarget {
     constructor() {
@@ -35,7 +34,7 @@ class RegistrationView extends events.EventTarget {
     renderRecaptcha() {
         grecaptcha.render(this._recaptchaNode, {
             "callback": this.setRecaptchaToken,
-            "sitekey": RECAPTCHA_SITE_KEY,
+            "sitekey": api.getRecaptchaSiteKey(),
         });
     }
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -24,7 +24,7 @@ RUN \
         alembic \
         "coloredlogs==5.0" \
         youtube-dl \
-    && apk --no-cache del py3-pip
+        requests
 
 ARG PUID=1000
 ARG PGID=1000

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -10,7 +10,8 @@ secret: change
 
 # Whether solving a captcha is required for registration for anonymous users.
 enable_recaptcha: no
-
+# The reCAPTCHA site key.
+recaptcha_site_key: change
 # A reCAPTCHA v2 secret token.
 # https://developers.google.com/recaptcha/intro
 # https://developers.google.com/recaptcha/docs/display

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -7,6 +7,13 @@ name: szurubooru
 domain: # example: http://example.com
 # used to salt the users' password hashes and generate filenames for static content
 secret: change
+
+# Whether solving a captcha is required for registration for anonymous users.
+enable_recaptcha: no
+
+# A reCAPTCHA v2 secret token.
+# https://developers.google.com/recaptcha/intro
+# https://developers.google.com/recaptcha/docs/display
 recaptcha_secret: change
 
 # Delete thumbnails and source files on post delete

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -7,6 +7,7 @@ name: szurubooru
 domain: # example: http://example.com
 # used to salt the users' password hashes and generate filenames for static content
 secret: change
+recaptcha_secret: change
 
 # Delete thumbnails and source files on post delete
 # Original functionality is no, to mitigate the impacts of admins going

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,3 +10,4 @@ pynacl>=1.2.1
 pytz>=2018.3
 pyRFC3339>=1.0
 youtube-dl
+requests

--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -49,6 +49,7 @@ def get_info(ctx: rest.Context, _params: Dict[str, str] = {}) -> rest.Response:
             "privileges": util.snake_case_to_lower_camel_case_keys(
                 config.config["privileges"]
             ),
+            "enableRecaptcha": config.config["enable_recaptcha"],
         },
     }
     if auth.has_privilege(ctx.user, "posts:view:featured"):

--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -50,6 +50,7 @@ def get_info(ctx: rest.Context, _params: Dict[str, str] = {}) -> rest.Response:
                 config.config["privileges"]
             ),
             "enableRecaptcha": config.config["enable_recaptcha"],
+            "recaptchaSiteKey": config.config["recaptcha_site_key"],
         },
     }
     if auth.has_privilege(ctx.user, "posts:view:featured"):

--- a/server/szurubooru/api/user_api.py
+++ b/server/szurubooru/api/user_api.py
@@ -42,7 +42,7 @@ def create_user(
         auth.verify_privilege(ctx.user, "users:create:any")
 
     # Verify if the recaptcha was correct.
-    if expect_recaptcha:
+    if expect_recaptcha and config.config["enable_recaptcha"]:
         resp = requests.post("https://www.google.com/recaptcha/api/siteverify", data={
             "secret": config.config["recaptcha_secret"],
             "response": ctx.get_param_as_string("recaptchaToken", default=""),

--- a/server/szurubooru/api/user_api.py
+++ b/server/szurubooru/api/user_api.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict
 
-from szurubooru import model, rest, search
+import requests
+
+from szurubooru import config, model, rest, search
 from szurubooru.func import auth, serialization, users, versions
 
 _search_executor = search.Executor(search.configs.UserSearchConfig())
@@ -31,10 +33,27 @@ def get_users(
 def create_user(
     ctx: rest.Context, _params: Dict[str, str] = {}
 ) -> rest.Response:
+    expect_recaptcha = False
+
     if ctx.user.user_id is None:
+        expect_recaptcha = True
         auth.verify_privilege(ctx.user, "users:create:self")
     else:
         auth.verify_privilege(ctx.user, "users:create:any")
+
+    # Verify if the recaptcha was correct.
+    if expect_recaptcha:
+        resp = requests.post("https://www.google.com/recaptcha/api/siteverify", data={
+            "secret": config.config["recaptcha_secret"],
+            "response": ctx.get_param_as_string("recaptchaToken", default=""),
+        })
+
+        # Raise a 400 error if the recaptcha wasn't OK.
+        if not resp.json()["success"]:
+            raise rest.errors.HttpBadRequest(
+                "ValidationError",
+                "Recaptcha response was invalid."
+            )
 
     name = ctx.get_param_as_string("name")
     password = ctx.get_param_as_string("password")


### PR DESCRIPTION
This added a recaptcha button to the registration page. The button only appears if recaptcha is enabled in the config and the user is not logged in.

I included a couple links in the config to the recaptcha docs. All that's needed to use it is to enable it in the config and provide the two tokens. By default the recaptcha is disabled.

```yaml
enable_recaptcha: yes
recaptcha_site_key: change-me
recaptcha_secret: change-me
```

## Captcha
![image](https://user-images.githubusercontent.com/2302541/86898230-6cda4680-c0d6-11ea-9ce5-8569cfe55c87.png)

## Captcha error message
![image](https://user-images.githubusercontent.com/2302541/86898335-93987d00-c0d6-11ea-805f-b7198119c2dc.png)
