### PR TITLE
client/posts: provide link for E621 image search

### DIFF
--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -53,6 +53,7 @@
             Search on
             <a href='http://iqdb.org/?url=<%- encodeURIComponent(ctx.post.fullContentUrl) %>'>IQDB</a> &middot;
             <a href='https://danbooru.donmai.us/posts?tags=md5:<%- ctx.post.checksumMD5 %>'>Danbooru</a> &middot;
+            <a href='https://e621.net/posts?tags=md5:<%- ctx.post.checksumMD5 %>'>E621</a> &middot;
             <a href='https://www.google.com/searchbyimage?&image_url=<%- encodeURIComponent(ctx.post.fullContentUrl) %>'>Google Images</a>
         </section>
 


### PR DESCRIPTION
Fork of danbooru, same URL structure. Covers content not found on IQDB or Danbooru due to subject matter.

May be prudent in the future to make this functionality editable via the database, instead of being determined from within the TPL.