### PR TITLE
client/posts: add post description

### DIFF
--- a/client/css/post-main-view.styl
+++ b/client/css/post-main-view.styl
@@ -40,10 +40,18 @@
         width: 100%
 
     .post-container
-        margin-bottom: 2em
+        margin-bottom: 0.6em
 
         .post-content
             margin: 0
+
+    .description-container
+        background: $top-navigation-color
+        padding: 0.6em
+
+    #post-description
+        resize: vertical
+        min-height: 200px
 
 @media (max-width: 800px)
     .post-view

--- a/client/html/post_main.tpl
+++ b/client/html/post_main.tpl
@@ -54,6 +54,18 @@
     <div class='content'>
         <div class='post-container'></div>
 
+        <% if (ctx.editMode) { %>
+            <h2>Description</h2>
+            <%= ctx.makeTextarea({
+                id: 'post-description',
+                value: ctx.post.description,
+            }) %>
+        <% } else if (ctx.post.description != undefined) { %>
+            <div class='description-container'>
+                <%= ctx.makeMarkdown(ctx.post.description) %>
+            </div>
+        <% } %>
+
         <% if (ctx.canListComments) { %>
             <div class='comments-container'></div>
         <% } %>

--- a/client/js/controllers/post_main_controller.js
+++ b/client/js/controllers/post_main_controller.js
@@ -187,6 +187,9 @@ class PostMainController extends BasePostController {
         if (e.detail.source !== undefined) {
             post.source = e.detail.source;
         }
+        if (e.detail.description !== undefined) {
+            post.description = e.detail.description;
+        }
         post.save().then(
             () => {
                 this._view.sidebarControl.showSuccess("Post saved.");

--- a/client/js/controls/post_edit_sidebar_control.js
+++ b/client/js/controls/post_edit_sidebar_control.js
@@ -435,6 +435,10 @@ class PostEditSidebarControl extends events.EventTarget {
                     source: this._sourceInputNode
                         ? this._sourceInputNode.value
                         : undefined,
+
+                    description: this._descriptionTextareaNode
+                        ? this._descriptionTextareaNode.value
+                        : undefined,
                 },
             })
         );
@@ -536,6 +540,10 @@ class PostEditSidebarControl extends events.EventTarget {
 
     get _noteTextareaNode() {
         return this._formNode.querySelector(".notes textarea");
+    }
+
+    get _descriptionTextareaNode() {
+        return document.querySelector("textarea#post-description");
     }
 
     enableForm() {

--- a/client/js/models/post.js
+++ b/client/js/models/post.js
@@ -102,6 +102,10 @@ class Post extends events.EventTarget {
         return this._flags;
     }
 
+    get description() {
+        return this._description;
+    }
+
     get tags() {
         return this._tags;
     }
@@ -152,6 +156,10 @@ class Post extends events.EventTarget {
 
     set flags(value) {
         this._flags = value;
+    }
+
+    set description(value) {
+        this._description = value;
     }
 
     set safety(value) {
@@ -276,6 +284,9 @@ class Post extends events.EventTarget {
         }
         if (this._source !== this._orig._source) {
             detail.source = this._source;
+        }
+        if (this._description !== this._orig._description) {
+            detail.description = this._description;
         }
 
         let apiPromise = this._id
@@ -484,6 +495,7 @@ class Post extends events.EventTarget {
             _fileSize: response.fileSize,
 
             _flags: [...(response.flags || [])],
+            _description: response.description,
             _relations: [...(response.relations || [])],
 
             _score: response.score,

--- a/client/js/views/post_main_view.js
+++ b/client/js/views/post_main_view.js
@@ -4,6 +4,7 @@ const iosCorrectedInnerHeight = require("ios-inner-height");
 const router = require("../router.js");
 const views = require("../util/views.js");
 const uri = require("../util/uri.js");
+const misc = require("../util/misc.js");
 const keyboard = require("../util/keyboard.js");
 const Touch = require("../util/touch.js");
 const PostContentControl = require("../controls/post_content_control.js");

--- a/server/szurubooru/api/post_api.py
+++ b/server/szurubooru/api/post_api.py
@@ -165,6 +165,11 @@ def update_post(ctx: rest.Context, params: Dict[str, str]) -> rest.Response:
     if ctx.has_file("thumbnail"):
         auth.verify_privilege(ctx.user, "posts:edit:thumbnail")
         posts.update_post_thumbnail(post, ctx.get_file("thumbnail"))
+    if ctx.has_param("description"):
+        # auth.verify_privilege(ctx.user, "posts:edit:description")
+        posts.update_post_description(
+            post, ctx.get_param_as_string("description")
+        )
     post.last_edit_time = datetime.utcnow()
     ctx.session.flush()
     snapshots.modify(post, ctx.user)

--- a/server/szurubooru/migrations/versions/58bba7e0c554_add_description_to_post.py
+++ b/server/szurubooru/migrations/versions/58bba7e0c554_add_description_to_post.py
@@ -1,0 +1,24 @@
+"""
+add_description_to_post
+
+Revision ID: 58bba7e0c554
+Created at: 2021-01-30 18:06:11.511449
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "58bba7e0c554"
+down_revision = "adcd63ff76a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "post", sa.Column("description", sa.UnicodeText(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("post", "description")

--- a/server/szurubooru/model/post.py
+++ b/server/szurubooru/model/post.py
@@ -213,6 +213,7 @@ class Post(Base):
     safety = sa.Column("safety", sa.Unicode(32), nullable=False)
     source = sa.Column("source", sa.Unicode(2048))
     flags_string = sa.Column("flags", sa.Unicode(32), default="")
+    description = sa.Column("description", sa.UnicodeText(), nullable=True)
 
     # content description
     type = sa.Column("type", sa.Unicode(32), nullable=False)


### PR DESCRIPTION
I've had this sitting in some far away directory for some time now, because I didn't like the design and the code.
I guess the best thing to do now is just ask some people for their opinion and/or improvements.

A few things I don't like/am not sure how to feel about:
- I am not sure if I like the padding the H1, H2, H3 tags add to the post description. It leaves an awful lot of empty space around the H1 tags (see first photo).
- I don't know whether I should show the `<h2>Description</h2>` on the edit page. (see 3rd and 4th photo).
- The code is inlined in `client/html/post_main.tpl`. Not sure if this is good or bad. (Reason for this is the extra div/h2 tags etc, which are just a pain to create in pure JS).

If you have other thoughts and/or tips please do share those too.

## Todo
- [ ] Post description edit permissions
- [ ] Idk?

## Images
[1. Post description](https://user-images.githubusercontent.com/50623835/106788262-04921a00-6651-11eb-9fcc-a677a5affc8d.png)
[2. Edit post description](https://user-images.githubusercontent.com/50623835/106788261-03f98380-6651-11eb-827f-29f61f5f225c.png)
[3. Edit post description resized](https://user-images.githubusercontent.com/50623835/106788259-0360ed00-6651-11eb-9634-edffd6aa086d.png)
[4. Edit post description (without H2)](https://user-images.githubusercontent.com/50623835/106789195-3b1c6480-6652-11eb-8d8b-a5c66be2327a.png)