### PR TITLE
Client CSS: Dark mode contrast fixes

### DIFF
--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -240,6 +240,9 @@ nav
                 background: $focused-tab-background-color-darktheme
     &#top-navigation
         background: $top-navigation-color-darktheme
+        ul
+            #mobile-navigation-toggle
+                color: $text-color-darktheme
 
 a .access-key
     text-decoration: underline

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -275,7 +275,7 @@ a .access-key
             background: darken($message-error-background-color, 60%)
         &.success
             border: 1px solid darken($message-success-border-color, 30%)
-            background: darken($message-success-background-color, 60%)
+            background: darken($message-success-background-color, 80%)
 
 .thumbnail
     /*background-image: attr(data-src url)*/ /* not available yet */

--- a/client/css/pager.styl
+++ b/client/css/pager.styl
@@ -22,7 +22,7 @@
                 z-index: 1
             span
                 position: relative
-                background: white
+                background: $window-color
                 padding: 0 1em
                 z-index: 2
 
@@ -31,3 +31,5 @@
         .page-header
             &:before
                 background: $top-navigation-color-darktheme
+            span
+                background: $window-color-darktheme

--- a/client/css/post-main-view.styl
+++ b/client/css/post-main-view.styl
@@ -27,7 +27,7 @@
                     padding: 0.3em 0
                     text-align: center
                     vertical-align: middle
-                    transition: background 0.2s linear
+                    transition: background 0.2s linear, box-shadow 0.2s linear
                     &:not(.inactive):hover
                         background: lighten($main-color, 90%)
                 i
@@ -44,6 +44,14 @@
 
         .post-content
             margin: 0
+
+.darktheme .post-view
+    >.sidebar
+        nav.buttons
+            article
+                a:not(.inactive):hover
+                    background: unset
+                    box-shadow: inset 0 0 0 0.3em $main-color
 
 @media (max-width: 800px)
     .post-view

--- a/client/css/tag-input-control.styl
+++ b/client/css/tag-input-control.styl
@@ -152,6 +152,8 @@ div.tag-input, ul.compact-tags
             background: $window-color-darktheme
             ul li:last-child
                 border-bottom: 0.5em solid alpha($window-color-darktheme, 0)
+            p
+                background: darken($tag-suggestions-header-color, 80%)
         .append
             color: $inactive-link-color-darktheme
     div.tag-input, ul.compact-tags

--- a/client/css/tag-input-control.styl
+++ b/client/css/tag-input-control.styl
@@ -92,7 +92,7 @@ div.tag-input
     to
         background-position: 0% 0%
 
-@keyframes new-tag-added
+@keyframes tag-added-to-post
     from
         max-height: 0
     to
@@ -110,28 +110,27 @@ ul.compact-tags
         overflow: hidden
         text-overflow: ellipsis
         transition: background-color 0.5s linear
+        background-size: 200%
         a
             display: inline
         a:focus
             outline: 0
             box-shadow: inset 0 0 0 2px $main-color
+        // these 3 added when tag is added to ul
         &.implication
-            // background: $implied-tag-background-color
             color: $implied-tag-text-color
-            background: linear-gradient(90deg, transparent, transparent, $implied-tag-background-color)
-            background-size: 200%
-            animation: tag-background-updated 2s ease forwards
+            background-image: linear-gradient(90deg, transparent, transparent, $implied-tag-background-color)
+            animation: tag-added-to-post 1s ease forwards, tag-background-updated 2s ease forwards
         &.new
-            // background: $new-tag-background-color
             color: $new-tag-text-color
-            background: linear-gradient(90deg, transparent, transparent, $new-tag-background-color)
-            background-size: 200%;
-            animation: new-tag-added 1s ease forwards, tag-background-updated 2s ease forwards
+            background-image: linear-gradient(90deg, transparent, transparent, $new-tag-background-color)
+            animation: tag-added-to-post 1s ease forwards, tag-background-updated 2s ease forwards
+        &.added
+            animation: tag-added-to-post 1s ease forwards
+        // highlight when already in tag list
         &.duplicate
-            // background: $duplicate-tag-background-color
             color: $duplicate-tag-text-color
-            background: linear-gradient(90deg, transparent, transparent, $duplicate-tag-background-color)
-            background-size: 200%
+            background-image: linear-gradient(90deg, transparent, transparent, $duplicate-tag-background-color)
             animation: tag-background-updated 2s ease forwards
     i
         padding-right: 0.4em

--- a/client/css/tag-input-control.styl
+++ b/client/css/tag-input-control.styl
@@ -86,12 +86,6 @@ div.tag-input
             font-size: 90%
             unselectable()
 
-@keyframes tag-background-updated
-    from
-        background-position: 200% 0%
-    to
-        background-position: 0% 0%
-
 @keyframes tag-added-to-post
     from
         max-height: 0
@@ -110,30 +104,34 @@ ul.compact-tags
         overflow: hidden
         text-overflow: ellipsis
         transition: background-color 0.5s linear
-        background-size: 200%
         a
             display: inline
         a:focus
             outline: 0
             box-shadow: inset 0 0 0 2px $main-color
         // these 3 added when tag is added to ul
+        &.added, &.new, &.implication
+            animation: tag-added-to-post 1s ease forwards
         &.implication
             color: $implied-tag-text-color
-            background-image: linear-gradient(90deg, transparent, transparent, $implied-tag-background-color)
-            animation: tag-added-to-post 1s ease forwards, tag-background-updated 2s ease forwards
+            background-color: $implied-tag-background-color
         &.new
             color: $new-tag-text-color
-            background-image: linear-gradient(90deg, transparent, transparent, $new-tag-background-color)
-            animation: tag-added-to-post 1s ease forwards, tag-background-updated 2s ease forwards
-        &.added
-            animation: tag-added-to-post 1s ease forwards
-        // highlight when already in tag list
+            background-color: $new-tag-background-color
         &.duplicate
             color: $duplicate-tag-text-color
-            background-image: linear-gradient(90deg, transparent, transparent, $duplicate-tag-background-color)
-            animation: tag-background-updated 2s ease forwards
+            background-color: $duplicate-tag-background-color
     i
         padding-right: 0.4em
+
+.darktheme ul.compact-tags
+    li
+        &.new
+            background-color: darken($new-tag-background-color, 80%)
+        &.implication
+            background-color: darken($implied-tag-background-color, 85%)
+        &.duplicate
+            background-color: darken($duplicate-tag-background-color, 80%)
 
 div.tag-input, ul.compact-tags
     .tag-usages, .tag-weight, .remove-tag

--- a/client/css/tag-input-control.styl
+++ b/client/css/tag-input-control.styl
@@ -86,6 +86,18 @@ div.tag-input
             font-size: 90%
             unselectable()
 
+@keyframes tag-background-updated
+    from
+        background-position: 200% 0%
+    to
+        background-position: 0% 0%
+
+@keyframes new-tag-added
+    from
+        max-height: 0
+    to
+        max-height: 5em
+
 ul.compact-tags
     width: 100%
     margin: 0.5em 0 0 0
@@ -104,14 +116,23 @@ ul.compact-tags
             outline: 0
             box-shadow: inset 0 0 0 2px $main-color
         &.implication
-            background: $implied-tag-background-color
+            // background: $implied-tag-background-color
             color: $implied-tag-text-color
+            background: linear-gradient(90deg, transparent, transparent, $implied-tag-background-color)
+            background-size: 200%
+            animation: tag-background-updated 2s ease forwards
         &.new
-            background: $new-tag-background-color
+            // background: $new-tag-background-color
             color: $new-tag-text-color
+            background: linear-gradient(90deg, transparent, transparent, $new-tag-background-color)
+            background-size: 200%;
+            animation: new-tag-added 1s ease forwards, tag-background-updated 2s ease forwards
         &.duplicate
-            background: $duplicate-tag-background-color
+            // background: $duplicate-tag-background-color
             color: $duplicate-tag-text-color
+            background: linear-gradient(90deg, transparent, transparent, $duplicate-tag-background-color)
+            background-size: 200%
+            animation: tag-background-updated 2s ease forwards
     i
         padding-right: 0.4em
 

--- a/client/js/controls/tag_input_control.js
+++ b/client/js/controls/tag_input_control.js
@@ -196,8 +196,11 @@ class TagInputControl extends events.EventTarget {
                 if (!tag.category) {
                     listItemNode.classList.add("new");
                 }
-                if (source === SOURCE_IMPLICATION) {
+                else if (source === SOURCE_IMPLICATION) {
                     listItemNode.classList.add("implication");
+                }
+                else {
+                    listItemNode.classList.add("added");
                 }
                 this._tagListNode.prependChild(listItemNode);
                 _fadeOutListItemNodeStatus(listItemNode);


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/5423266/114247680-b1e02180-9963-11eb-8ef6-820d63b5fd5d.png)

After:

![image](https://user-images.githubusercontent.com/5423266/114469970-0c73ba80-9bbc-11eb-8f94-2609d6da16c5.png)

Changes:
 - Above fix for page headers in dark mode
 - Changes the tag input bg highlighting to a CSS animation in order to better maintain readability of the tag name
 - In dark mode uses an outline box-shadow instead of bg highlight for post nav buttons
 - Darkens darktheme.message.success bg for readability contrast