### PR TITLE
Fix #385

### DIFF
--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -92,7 +92,7 @@
                             --></a><!--
                         --><% } %><!--
                         --><% if (ctx.canListPosts) { %><!--
-                            --><a href='<%- ctx.formatClientLink('posts', {query: ctx.escapeColons(tag.names[0])}) %>' class='<%= ctx.makeCssName(tag.category, 'tag') %>'><!--
+                            --><a href='<%- ctx.formatClientLink('posts', {query: ctx.escapeTagName(tag.names[0])}) %>' class='<%= ctx.makeCssName(tag.category, 'tag') %>'><!--
                         --><% } %><!--
                             --><%- ctx.getPrettyName(tag.names[0]) %>&#32;<!--
                         --><% if (ctx.canListPosts) { %><!--

--- a/client/html/tag_delete.tpl
+++ b/client/html/tag_delete.tpl
@@ -1,6 +1,6 @@
 <div class='tag-delete'>
     <form>
-        <p>This tag has <a href='<%- ctx.formatClientLink('posts', {query: ctx.escapeColons(ctx.tag.names[0])}) %>'><%- ctx.tag.postCount %> usage(s)</a>.</p>
+        <p>This tag has <a href='<%- ctx.formatClientLink('posts', {query: ctx.escapeTagName(ctx.tag.names[0])}) %>'><%- ctx.tag.postCount %> usage(s)</a>.</p>
 
         <ul class='input'>
             <li>

--- a/client/html/tag_summary.tpl
+++ b/client/html/tag_summary.tpl
@@ -36,6 +36,6 @@
     <section class='description'>
         <hr/>
         <%= ctx.makeMarkdown(ctx.tag.description || 'This tag has no description yet.') %>
-        <p>This tag has <a href='<%- ctx.formatClientLink('posts', {query: ctx.escapeColons(ctx.tag.names[0])}) %>'><%- ctx.tag.postCount %> usage(s)</a>.</p>
+        <p>This tag has <a href='<%- ctx.formatClientLink('posts', {query: ctx.escapeTagName(ctx.tag.names[0])}) %>'><%- ctx.tag.postCount %> usage(s)</a>.</p>
     </section>
 </div>

--- a/client/js/controllers/pool_controller.js
+++ b/client/js/controllers/pool_controller.js
@@ -52,7 +52,7 @@ class PoolController {
                     canMerge: api.hasPrivilege("pools:merge"),
                     canDelete: api.hasPrivilege("pools:delete"),
                     categories: categories,
-                    escapeColons: uri.escapeColons,
+                    escapeTagName: uri.escapeTagName,
                 });
 
                 this._view.addEventListener("change", (e) =>

--- a/client/js/controllers/pool_create_controller.js
+++ b/client/js/controllers/pool_create_controller.js
@@ -26,7 +26,7 @@ class PoolCreateController {
                 this._view = new PoolCreateView({
                     canCreate: api.hasPrivilege("pools:create"),
                     categories: categories,
-                    escapeColons: uri.escapeColons,
+                    escapeTagName: uri.escapeTagName,
                 });
 
                 this._view.addEventListener("submit", (e) =>

--- a/client/js/controllers/tag_controller.js
+++ b/client/js/controllers/tag_controller.js
@@ -56,7 +56,7 @@ class TagController {
                     canMerge: api.hasPrivilege("tags:merge"),
                     canDelete: api.hasPrivilege("tags:delete"),
                     categories: categories,
-                    escapeColons: uri.escapeColons,
+                    escapeTagName: uri.escapeTagName,
                 });
 
                 this._view.addEventListener("change", (e) =>

--- a/client/js/controls/post_readonly_sidebar_control.js
+++ b/client/js/controls/post_readonly_sidebar_control.js
@@ -28,7 +28,7 @@ class PostReadonlySidebarControl extends events.EventTarget {
                 canListPosts: api.hasPrivilege("posts:list"),
                 canEditPosts: api.hasPrivilege("posts:edit"),
                 canViewTags: api.hasPrivilege("tags:view"),
-                escapeColons: uri.escapeColons,
+                escapeTagName: uri.escapeTagName,
                 extractRootDomain: uri.extractRootDomain,
                 getPrettyName: misc.getPrettyName,
             })

--- a/client/js/controls/tag_input_control.js
+++ b/client/js/controls/tag_input_control.js
@@ -305,7 +305,7 @@ class TagInputControl extends events.EventTarget {
         searchLinkNode.setAttribute(
             "href",
             uri.formatClientLink("posts", {
-                query: uri.escapeColons(tag.names[0]),
+                query: uri.escapeTagName(tag.names[0]),
             })
         );
         searchLinkNode.textContent = tag.names[0] + " ";

--- a/client/js/controls/tag_input_control.js
+++ b/client/js/controls/tag_input_control.js
@@ -163,7 +163,8 @@ class TagInputControl extends events.EventTarget {
 
     addTagByName(name, source) {
         name = name.trim();
-        if (!name) {
+        // Tags `.` and `..` are not allowed, see https://github.com/rr-/szurubooru/pull/390
+        if (!name || name == "." || name == "..") {
             return;
         }
         return Tag.get(name).then(

--- a/client/js/util/misc.js
+++ b/client/js/util/misc.js
@@ -187,7 +187,7 @@ function arraysDiffer(source1, source2, orderImportant) {
 }
 
 function escapeSearchTerm(text) {
-    return text.replace(/([a-z_-]):/g, "$1\\:");
+    return text.replace(/([a-z_-]):/g, "$1\\:").replace(/\./g, "\\.");
 }
 
 function dataURItoBlob(dataURI) {

--- a/client/js/util/uri.js
+++ b/client/js/util/uri.js
@@ -85,14 +85,14 @@ function extractRootDomain(url) {
     return domain;
 }
 
-function escapeColons(text) {
-    return text.replace(new RegExp(":", "g"), "\\:");
+function escapeTagName(text) {
+    return text.replace(/:/g, "\\:").replace(/\./g, "\\.");
 }
 
 module.exports = {
     formatClientLink: formatClientLink,
     formatApiLink: formatApiLink,
-    escapeColons: escapeColons,
+    escapeTagName: escapeTagName,
     escapeParam: escapeParam,
     unescapeParam: unescapeParam,
     extractHostname: extractHostname,


### PR DESCRIPTION
Currently this does not fix the issue which arises when you go to view/edit a tag that is just dots, e.g `.` and `..`

This is probably because `.` means 'this directory' and `..` means 'parent directory'. I don't think having a tag like `..` is realistic, but feel free to correct me. Maybe escaping the dot as `%2E` would work, but [apparently this behavior differs between browsers.](https://stackoverflow.com/a/3857067)

This fails:
```sh
# View/edit tag with just dots
http://localhost/tag/.
http://localhost/tag/..

# This does work on my prod server, more on that below
http://localhost/tag/...
# etc
```

This works:
```sh
# Search for tag '...' escaped as '\.\.\.'
http://localhost/posts/query=%5C.%5C.%5C.
# Search for tag 'test...' escaped as 'test\.\.\.'
http://localhost/posts/query=test%5C.%5C.%5C.
```

However, some things work fine on my prod server, but not on my test setup.
```sh
# Works on prod, not on test. But I suspect that my test server is not configured correctly.
http://localhost/tag/test..
http://localhost/tag/test...
http://localhost/tag/...
```

Prod: linux with nginx (not docker)
Test: windows with nginx (not docker)

The difference is that `query=xxx` uses an escaped input, whereas `/tag/xxx` does NOT use an escaped input. 
On my production server `/tag/.../` works, but doesn't work with `.` and `..`, probably because `.` and `..` have a special meaning.

TL;DR:
- The `escapeTagName` function now also escapes dots, which fixes the issue illustrated in #385.
- Supporting `.` and `..` as a tag names seems unnecessarily complex, because of the special meaning of these dots.
- `/tag/***` does not use an escaped input. On my prod server this works fine, on my test server it does not. On my test server it seems to ignore the trailing dots, e.g. `test..test..` is recognized as `test..test`. In Fernsicles' video it seems to behave the same as on my prod server, aka the expected behavior. So maybe my test setup is just wrongly configured?