### PR TITLE
Suppressed the use of SQLAlchemy 1.4

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,7 @@
 alembic>=0.8.5
 pyyaml>=3.11
 psycopg2-binary>=2.6.1
-SQLAlchemy>=1.0.12
+SQLAlchemy>=1.0.12, <1.4
 coloredlogs==5.0
 certifi>=2017.11.5
 numpy>=1.8.2


### PR DESCRIPTION
If the current requirements.txt is used and deployed in the on-premises environment, SQLAlchemy 1.4 series will be introduced and the test will not pass due to compatibility issues.

Therefore, we need to suppress the use of SQLAlchemy 1.4.