### PR TITLE
Improve uploading process

### DIFF
--- a/client/css/post-upload.styl
+++ b/client/css/post-upload.styl
@@ -13,8 +13,10 @@ $cancel-button-color = tomato
 
         &.inactive input[type=submit],
         &.inactive .skip-duplicates
+        &.inactive .always-upload-similar
         &.uploading input[type=submit],
         &.uploading .skip-duplicates,
+        &.uploading .always-upload-similar
         &:not(.uploading) .cancel
             display: none
 
@@ -37,6 +39,9 @@ $cancel-button-color = tomato
             border: 2px solid $text-color
 
     .skip-duplicates
+        margin-left: 1em
+
+    .always-upload-similar
         margin-left: 1em
 
     form>.messages

--- a/client/html/post_upload.tpl
+++ b/client/html/post_upload.tpl
@@ -13,6 +13,14 @@
                 }) %>
             </span>
 
+            <span class='always-upload-similar'>
+                <%= ctx.makeCheckbox({
+                    text: 'Always upload similar',
+                    name: 'always-upload-similar',
+                    checked: false,
+                }) %>
+            </span>
+
             <input type='button' value='Cancel' class='cancel'/>
         </div>
 

--- a/client/js/controllers/post_upload_controller.js
+++ b/client/js/controllers/post_upload_controller.js
@@ -12,7 +12,7 @@ const PostUploadView = require("../views/post_upload_view.js");
 const EmptyView = require("../views/empty_view.js");
 
 const genericErrorMessage =
-    "One of the posts needs your attention; " +
+    "One or more posts needs your attention; " +
     'click "resume upload" when you\'re ready.';
 
 class PostUploadController {
@@ -55,6 +55,7 @@ class PostUploadController {
     _evtSubmit(e) {
         this._view.disableForm();
         this._view.clearMessages();
+        let anyFailures = false;
 
         e.detail.uploadables
             .reduce(
@@ -64,37 +65,43 @@ class PostUploadController {
                             uploadable,
                             e.detail.skipDuplicates
                         )
+                        .catch((error) => {
+                            anyFailures = true;
+                            if (error.uploadable) {
+                                if (error.similarPosts) {
+                                    error.uploadable.lookalikes = error.similarPosts;
+                                    this._view.updateUploadable(error.uploadable);
+                                    this._view.showInfo(
+                                        error.message,
+                                        error.uploadable
+                                    );
+                                } else {
+                                    this._view.showError(
+                                        error.message,
+                                        error.uploadable
+                                    );
+                                }
+                            } else {
+                                this._view.showError(
+                                    error.message,
+                                    error.uploadable
+                                );
+                            }
+                        })
                     ),
                 Promise.resolve()
             )
             .then(
                 () => {
-                    this._view.clearMessages();
-                    misc.disableExitConfirmation();
-                    const ctx = router.show(uri.formatClientLink("posts"));
-                    ctx.controller.showSuccess("Posts uploaded.");
-                },
-                (error) => {
-                    if (error.uploadable) {
-                        if (error.similarPosts) {
-                            error.uploadable.lookalikes = error.similarPosts;
-                            this._view.updateUploadable(error.uploadable);
-                            this._view.showInfo(genericErrorMessage);
-                            this._view.showInfo(
-                                error.message,
-                                error.uploadable
-                            );
-                        } else {
-                            this._view.showError(genericErrorMessage);
-                            this._view.showError(
-                                error.message,
-                                error.uploadable
-                            );
-                        }
+                    if (anyFailures) {
+                        this._view.showError(genericErrorMessage);
+                        this._view.enableForm();
                     } else {
-                        this._view.showError(error.message);
+                        this._view.clearMessages();
+                        misc.disableExitConfirmation();
+                        const ctx = router.show(uri.formatClientLink("posts"));
+                        ctx.controller.showSuccess("Posts uploaded.");
                     }
-                    this._view.enableForm();
                 }
             );
     }

--- a/client/js/controllers/post_upload_controller.js
+++ b/client/js/controllers/post_upload_controller.js
@@ -63,7 +63,8 @@ class PostUploadController {
                     promise.then(() =>
                         this._uploadSinglePost(
                             uploadable,
-                            e.detail.skipDuplicates
+                            e.detail.skipDuplicates,
+                            e.detail.alwaysUploadSimilar
                         )
                         .catch((error) => {
                             anyFailures = true;
@@ -84,7 +85,7 @@ class PostUploadController {
                             } else {
                                 this._view.showError(
                                     error.message,
-                                    error.uploadable
+                                    uploadable
                                 );
                             }
                         })
@@ -106,7 +107,7 @@ class PostUploadController {
             );
     }
 
-    _uploadSinglePost(uploadable, skipDuplicates) {
+    _uploadSinglePost(uploadable, skipDuplicates, alwaysUploadSimilar) {
         progress.start();
         let reverseSearchPromise = Promise.resolve();
         if (!uploadable.lookalikesConfirmed) {
@@ -135,7 +136,7 @@ class PostUploadController {
                     }
 
                     // notify about similar posts
-                    if (searchResult.similarPosts.length) {
+                    if (searchResult.similarPosts.length && !alwaysUploadSimilar) {
                         let error = new Error(
                             `Found ${searchResult.similarPosts.length} similar ` +
                                 "posts.\nYou can resume or discard this upload."

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -350,6 +350,7 @@ class PostUploadView extends events.EventTarget {
                 detail: {
                     uploadables: this._uploadables,
                     skipDuplicates: this._skipDuplicatesCheckboxNode.checked,
+                    alwaysUploadSimilar: this._alwaysUploadSimilarCheckboxNode.checked,
                 },
             })
         );
@@ -411,6 +412,10 @@ class PostUploadView extends events.EventTarget {
 
     get _skipDuplicatesCheckboxNode() {
         return this._hostNode.querySelector("form [name=skip-duplicates]");
+    }
+
+    get _alwaysUploadSimilarCheckboxNode() {
+        return this._hostNode.querySelector("form [name=always-upload-similar]");
     }
 
     get _submitButtonNode() {


### PR DESCRIPTION
I wanted to fix two minor things about the upload page:

1. If you have a large number of files to upload but one of the files early on has an upload error, it will prevent all the files below it from being uploaded. For upload jobs with many files, it's really annoying to have to manually intervene after each error. I changed the way errors are handled so that if one post has an error the rest will continue uploading, and all the posts with errors will remain afterwards. (This could be made configurable if the behavior is actually undesirable.)
2. Some kinds of images like screenshots can naturally be similar to one another, but there is no way to tell the uploader that you don't care about similarity when uploading. I added a new option, "Always upload similar", which will skip the confirmation when a similar image is detected.

With these two enhancements it should be possible to send a large upload job and guarantee that all the images that are both of a supported format and not exact duplicates will be uploaded.