### PR TITLE
Upload from clipboard

### DIFF
--- a/client/js/controls/file_dropper_control.js
+++ b/client/js/controls/file_dropper_control.js
@@ -19,8 +19,7 @@ class FileDropperControl extends events.EventTarget {
             lock: options.lock,
             id: "file-" + Math.random().toString(36).substring(7),
             urlPlaceholder:
-                options.urlPlaceholder ||
-                "Alternatively, paste an image or URL here.",
+                options.urlPlaceholder || "Alternatively, paste an URL here.",
         });
 
         this._dropperNode = source.querySelector(".file-dropper");
@@ -49,14 +48,16 @@ class FileDropperControl extends events.EventTarget {
             this._urlInputNode.addEventListener("keydown", (e) =>
                 this._evtUrlInputKeyDown(e)
             );
-            this._urlInputNode.addEventListener("paste", (e) =>
-                this._evtPaste(e)
-            );
         }
         if (this._urlConfirmButtonNode) {
             this._urlConfirmButtonNode.addEventListener("click", (e) =>
                 this._evtUrlConfirmButtonClick(e)
             );
+        }
+
+        document.onpaste = (e) => {
+            if (!document.querySelector(".file-dropper")) return;
+            this._evtPaste(e)
         }
 
         this._originalHtml = this._dropperNode.innerHTML;
@@ -135,7 +136,7 @@ class FileDropperControl extends events.EventTarget {
 
     _evtPaste(e) {
         const items = (e.clipboardData || e.originalEvent.clipboardData).items;
-        const fileList = Array.from(items).map((x) => x.getAsFile());
+        const fileList = Array.from(items).map((x) => x.getAsFile()).filter(f => f);
 
         if (!this._options.allowMultiple && fileList.length > 1) {
             window.alert("Cannot select multiple files.");

--- a/client/js/controls/file_dropper_control.js
+++ b/client/js/controls/file_dropper_control.js
@@ -56,7 +56,7 @@ class FileDropperControl extends events.EventTarget {
         }
 
         document.onpaste = (e) => {
-            if (!document.querySelector(".file-dropper")) return;
+            if (!document.getElementById("post-upload")) return;
             this._evtPaste(e)
         }
 

--- a/client/js/controls/file_dropper_control.js
+++ b/client/js/controls/file_dropper_control.js
@@ -139,7 +139,7 @@ class FileDropperControl extends events.EventTarget {
 
         if (!this._options.allowMultiple && fileList.length > 1) {
             window.alert("Cannot select multiple files.");
-        } else {
+        } else if (fileList.length > 0) {
             this._emitFiles(fileList);
         }
     }

--- a/client/js/controls/file_dropper_control.js
+++ b/client/js/controls/file_dropper_control.js
@@ -19,7 +19,8 @@ class FileDropperControl extends events.EventTarget {
             lock: options.lock,
             id: "file-" + Math.random().toString(36).substring(7),
             urlPlaceholder:
-                options.urlPlaceholder || "Alternatively, paste an URL here.",
+                options.urlPlaceholder ||
+                "Alternatively, paste an image or URL here.",
         });
 
         this._dropperNode = source.querySelector(".file-dropper");
@@ -47,6 +48,9 @@ class FileDropperControl extends events.EventTarget {
         if (this._urlInputNode) {
             this._urlInputNode.addEventListener("keydown", (e) =>
                 this._evtUrlInputKeyDown(e)
+            );
+            this._urlInputNode.addEventListener("paste", (e) =>
+                this._evtPaste(e)
             );
         }
         if (this._urlConfirmButtonNode) {
@@ -127,6 +131,17 @@ class FileDropperControl extends events.EventTarget {
             window.alert("Cannot select multiple files.");
         }
         this._emitFiles(e.dataTransfer.files);
+    }
+
+    _evtPaste(e) {
+        const items = (e.clipboardData || e.originalEvent.clipboardData).items;
+        const fileList = Array.from(items).map((x) => x.getAsFile());
+
+        if (!this._options.allowMultiple && fileList.length > 1) {
+            window.alert("Cannot select multiple files.");
+        } else {
+            this._emitFiles(fileList);
+        }
     }
 
     _evtUrlInputKeyDown(e) {

--- a/client/js/controls/file_dropper_control.js
+++ b/client/js/controls/file_dropper_control.js
@@ -48,6 +48,12 @@ class FileDropperControl extends events.EventTarget {
             this._urlInputNode.addEventListener("keydown", (e) =>
                 this._evtUrlInputKeyDown(e)
             );
+            this._urlInputNode.addEventListener("paste", (e) => {
+                // document.onpaste is used on the post-upload page.
+                // And this event is used on the post edit page.
+                if (document.getElementById("post-upload")) return;
+                this._evtPaste(e)
+            });
         }
         if (this._urlConfirmButtonNode) {
             this._urlConfirmButtonNode.addEventListener("click", (e) =>


### PR DESCRIPTION
A few small issues.

#### 1. You can only paste an image in the text input

This could be fixed by changing `this._urlInputNode.addEventListener("paste", ...)` to `window.onpaste = ...;`, but it feels a bit dirty to  touch the window. We can't use `window.addEventListener` because I don't think we have an 'unmounted' event where we can call `removeEventListener`. Though the same is true when using `window.onpaste`, but at least then it wouldn't add duplicate listeners when mounting the upload view multiple times (happens when navigating from upload -> another page -> upload again).

#### 2. The "Change post content" upload field text is unchanged

Because it wouldn't fit. Any suggestions?

How it is now:
![image](https://user-images.githubusercontent.com/50623835/120845232-cfe78e00-c570-11eb-83df-1706ef150734.png)

How it would be with the change:
![image](https://user-images.githubusercontent.com/50623835/120845330-f60d2e00-c570-11eb-9c2d-9c5ba1c40e91.png)

#### 3. No feedback when the clipboard can't be accessed

This doesn't work when the user has some privacy settings enabled (though at that point it also wouldn't work on imgur etc). I wouldn't know which specific setting. It doesn't work on my personal Chrome/Firefox setup, but it works in a 'clean' Edge (Chromium).