### PR TITLE
Nginx / Lua based approach to Open Graph tags

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,6 +18,7 @@ COPY docker-start.sh /
 
 WORKDIR /etc/nginx
 COPY nginx.conf.docker ./nginx.conf
+COPY metatags.lua .
 
 WORKDIR /var/www
 COPY --from=builder /opt/app/public/ .
@@ -26,7 +27,8 @@ COPY --from=builder /opt/app/public/ .
 FROM openresty/openresty:alpine-fat as release
 
 RUN apk --no-cache add dumb-init
-RUN /usr/local/openresty/luajit/bin/luarocks install gumbo
+RUN opm get bungle/lua-resty-template
+# RUN /usr/local/openresty/luajit/bin/luarocks install gumbo
 COPY --from=approot / /
 
 CMD ["/docker-start.sh"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -23,9 +23,10 @@ WORKDIR /var/www
 COPY --from=builder /opt/app/public/ .
 
 
-FROM nginx:alpine as release
+FROM openresty/openresty:alpine-fat as release
 
 RUN apk --no-cache add dumb-init
+RUN /usr/local/openresty/luajit/bin/luarocks install gumbo
 COPY --from=approot / /
 
 CMD ["/docker-start.sh"]

--- a/client/docker-start.sh
+++ b/client/docker-start.sh
@@ -8,4 +8,5 @@ sed -i "s|__BASEURL__|${BASE_URL:-/}|g" \
     /var/www/manifest.json
 
 # Start server
-exec nginx
+echo "$0 starting server..."
+exec openresty -c /etc/nginx/nginx.conf

--- a/client/html/index.htm
+++ b/client/html/index.htm
@@ -22,6 +22,7 @@
     <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-1668x2224.png' media='(min-device-width: 834px) and (max-device-width: 834px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
     <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-2048x2732.png' media='(min-device-width: 1024px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
     <link rel='manifest' href='manifest.json'/>
+    {{ generated_head_tags }}
 </head>
 <body>
     <div id='top-navigation-holder'></div>

--- a/client/metatags.lua
+++ b/client/metatags.lua
@@ -1,0 +1,32 @@
+ngx.req.read_body()
+
+local page_html = ngx.location.capture("/index.htm")
+
+ngx.req.set_header("Accept", "application/json")
+local server_info = cjson.decode((ngx.location.capture("/_internal_api/info")).body)
+
+-- local document = gumbo.parse(page_html.body)
+--
+-- function add_meta_tag (property, content)
+--   local new_element = document:createElement("meta")
+--   document.head:appendChild(new_element)
+--   new_element:setAttribute("property", property)
+--   new_element:setAttribute("content", content)
+-- end
+
+local additional_tags = ""
+
+local function add_meta_tag (property, content)
+  additional_tags = additional_tags .. "<meta property=\"" .. property .. "\" content=\"" .. content:gsub('"', '\\"') .. "\" />"
+end
+
+-- Add the site name tag
+add_meta_tag("og:site_name", server_info.config.name)
+
+local final_response = page_html.body:gsub("{{ generated_head_tags }}", additional_tags)
+
+-- Set the content type back to HTML
+ngx.header.content_type = 'text/html';
+
+-- ngx.say(page_html.body)
+ngx.say(final_response)

--- a/client/metatags.lua
+++ b/client/metatags.lua
@@ -17,11 +17,12 @@ local server_info = cjson.decode((ngx.location.capture("/_internal_api/info")).b
 local additional_tags = ""
 
 local function add_meta_tag (property, content)
-  additional_tags = additional_tags .. "<meta property=\"" .. property .. "\" content=\"" .. content:gsub('"', '\\"') .. "\" />"
+  additional_tags = additional_tags .. "<meta property=\"" .. property .. "\" content=\"" .. content:gsub('"', '\\"') .. "\"/>"
 end
 
 -- Add the site name tag
 add_meta_tag("og:site_name", server_info.config.name)
+add_meta_tag("og:url", ngx.var.scheme .. "://" .. ngx.var.http_host .. ngx.var.request_uri)
 
 local final_response = page_html.body:gsub("{{ generated_head_tags }}", additional_tags)
 

--- a/client/nginx.conf.docker
+++ b/client/nginx.conf.docker
@@ -50,6 +50,9 @@ http {
             gzip_proxied expired no-cache no-store private auth;
             gzip_types text/plain application/json;
 
+            proxy_connect_timeout 180s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 600s;
             if ($request_uri ~* "/api/(.*)") {
                 proxy_pass http://backend/$1;
             }

--- a/client/nginx.conf.docker
+++ b/client/nginx.conf.docker
@@ -27,7 +27,7 @@ http {
 
     init_by_lua_block {
         cjson = require("cjson")
-        gumbo = require("gumbo")
+        -- gumbo = require("gumbo")
     }
 
     server {
@@ -81,7 +81,7 @@ http {
 
         location / {
             root /var/www;
-            try_files $uri /index.htm;
+            try_files $uri /_og_tags_html;
 
             sendfile on;
             tcp_nopush on;
@@ -104,23 +104,9 @@ http {
             proxy_pass http://backend/$1;
         }
 
-        location ~ ^/_internal_tag_generator/(.*)$ {
-            content_by_lua_block {
-                ngx.say("")
-            }
-        }
         location /_og_tags_html {
             root /var/www;
-            content_by_lua_block {
-                ngx.req.read_body()
-
-                local page_html = ngx.location.capture("/index.htm")
-                ngx.say(page_html.body)
-
-                ngx.req.set_header("Accept", "application/json")
-                local server_info = cjson.decode((ngx.location.capture("/_internal_api/info")).body)
-                ngx.say(server_info.config.name)
-            }
+            content_by_lua_file /etc/nginx/metatags.lua;
         }
 
         location @unauthorized {

--- a/client/nginx.conf.docker
+++ b/client/nginx.conf.docker
@@ -81,7 +81,7 @@ http {
 
         location / {
             root /var/www;
-            try_files $uri /_og_tags_html;
+            try_files $uri /_meta_tags_html;
 
             sendfile on;
             tcp_nopush on;
@@ -104,7 +104,8 @@ http {
             proxy_pass http://backend/$1;
         }
 
-        location /_og_tags_html {
+        location /_meta_tags_html {
+            internal;
             root /var/www;
             content_by_lua_file /etc/nginx/metatags.lua;
         }

--- a/client/nginx.conf.docker
+++ b/client/nginx.conf.docker
@@ -1,5 +1,7 @@
 worker_processes 1;
-user nginx;
+user nobody;
+
+pcre_jit on;
 
 error_log /dev/stderr warn;
 pid /var/run/nginx.pid;
@@ -9,7 +11,7 @@ events {
 }
 
 http {
-    include /etc/nginx/mime.types;
+    include /usr/local/openresty/nginx/conf/mime.types;
     default_type application/octet-stream;
 
     log_format main '$remote_addr -> $request [$status] - '
@@ -21,6 +23,11 @@ http {
 
     upstream backend {
         server __BACKEND__:6666;
+    }
+
+    init_by_lua_block {
+        cjson = require("cjson")
+        gumbo = require("gumbo")
     }
 
     server {
@@ -82,6 +89,38 @@ http {
 
             gzip_static on;
             gzip_proxied expired no-cache no-store private auth;
+        }
+
+        location ~ ^/_internal_api/(.*)$ {
+            internal;
+            tcp_nodelay on;
+
+            add_header 'Access-Control-Allow-Origin' '*';
+
+            gzip off;
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 10s;
+            proxy_read_timeout 10s;
+            proxy_pass http://backend/$1;
+        }
+
+        location ~ ^/_internal_tag_generator/(.*)$ {
+            content_by_lua_block {
+                ngx.say("")
+            }
+        }
+        location /_og_tags_html {
+            root /var/www;
+            content_by_lua_block {
+                ngx.req.read_body()
+
+                local page_html = ngx.location.capture("/index.htm")
+                ngx.say(page_html.body)
+
+                ngx.req.set_header("Accept", "application/json")
+                local server_info = cjson.decode((ngx.location.capture("/_internal_api/info")).body)
+                ngx.say(server_info.config.name)
+            }
         }
 
         location @unauthorized {


### PR DESCRIPTION
This is an alternative option for #416 which I believe has the following benefits compared to #421 

- Does not require any additional processes, containers, or listening ports
- Much lower memory & cpu footprint vs an additional python server ( =handling more traffic)
- Smaller container size vs adding another Python webserver container

There are some issues with this implementation which I want to fix first though:

- The openresty image is much larger than the bare nginx image (101MB vs 22MB) so I would like to just add on the Lua module to the Nginx image ourselves (22+??MB) (although there are some additional complications with that process which I am still sorting out, like runtime Lua optimizations being missing in the manual install on nginx)
- 