### PR TITLE
client: remove URL rewriting from the markdown handler

### DIFF
--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -65,17 +65,6 @@ class TagPermalinkFixWrapper extends BaseMarkdownWrapper {
 // post, user and tags permalinks
 class EntityPermalinkWrapper extends BaseMarkdownWrapper {
     preprocess(text) {
-        // URL-based permalinks
-        text = text.replace(new RegExp("\\b/post/(\\d+)/?\\b", "g"), "@$1");
-        text = text.replace(
-            new RegExp("\\b/tag/([a-zA-Z0-9_-]+?)/?", "g"),
-            "#$1"
-        );
-        text = text.replace(
-            new RegExp("\\b/user/([a-zA-Z0-9_-]+?)/?", "g"),
-            "+$1"
-        );
-
         text = text.replace(
             /(^|^\(|(?:[^\]])\(|[\s<>\[\]\)])([+#@][a-zA-Z0-9_-]+)/g,
             "$1[$2]($2)"


### PR DESCRIPTION
Removes the URL rewriting logic from the markdown handler, as discussed in #429

Fixes stuff like `[Really cool art!](https://booru.example.com/post/1337)` being rewritten to `[Really cool art!](https://booru.example.com@1337)`

Technically speaking this is a breaking change.