### PR TITLE
updated build files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,29 @@
 repos:
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: mixed-line-ending
 
+
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.1.10
     hooks:
     -   id: remove-tabs
 
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.11b1
     hooks:
       - id: black
         files: 'server/'
         types: [python]
-        language_version: python3.8
+        language_version: python3.9
 
--   repo: https://github.com/timothycrosley/isort
-    rev: '5.4.2'
+-   repo: https://github.com/PyCQA/isort
+    rev: '5.10.1'
     hooks:
     -   id: isort
         files: 'server/'
@@ -31,8 +32,8 @@ repos:
         additional_dependencies:
         -   toml
 
--   repo: https://github.com/prettier/prettier
-    rev: '2.1.1'
+-   repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.5.0
     hooks:
     -   id: prettier
         files: client/js/
@@ -40,7 +41,7 @@ repos:
         args: ['--config', 'client/.prettierrc.yml']
 
 -   repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v7.8.0
+    rev: v8.3.0
     hooks:
     -   id: eslint
         files: client/js/
@@ -48,8 +49,8 @@ repos:
         additional_dependencies:
         -   eslint-config-prettier
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.3'
+-   repo: https://gitlab.com/PyCQA/flake8
+    rev: '4.0.1'
     hooks:
     -   id: flake8
         files: server/szurubooru/

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM node:lts as builder
 WORKDIR /opt/app
 
 COPY package.json package-lock.json ./
-RUN npm install -g npm@lts
+RUN npm install -g npm
 RUN npm install
 
 COPY . ./


### PR DESCRIPTION
- `npm i -g npm@lts` (in client/Dockerfile) is no longer valid as per https://github.com/npm/cli/wiki/Support-Policy#long-term-support-lts
- updated pre-commit config to use latest repos

the commit message somehow omitted `npm i -g npm@lts`, weird