### PR TITLE
Set common tags for all uploads, with auto-completion

### DIFF
--- a/client/css/post-upload.styl
+++ b/client/css/post-upload.styl
@@ -15,6 +15,7 @@ $cancel-button-color = tomato
         &.inactive .skip-duplicates
         &.inactive .always-upload-similar
         &.inactive .pause-remain-on-error
+        &.inactive #common-tags,
         &.uploading input[type=submit],
         &.uploading .skip-duplicates,
         &.uploading .always-upload-similar
@@ -29,6 +30,9 @@ $cancel-button-color = tomato
             padding: 2em
             small
                 font-size: 60%
+    
+    label[for=common-tags]
+        display: none !important
 
     input[type=submit]
         margin-top: 1em

--- a/client/html/post_upload.tpl
+++ b/client/html/post_upload.tpl
@@ -29,6 +29,8 @@
                 }) %>
             </span>
 
+            <%= ctx.makeTextInput({placeholder: 'Common tags', id: 'common-tags', name: 'common-tags', style: 'margin-top:1em;'}) %>
+
             <input type='button' value='Cancel' class='cancel'/>
         </div>
 

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -8,6 +8,10 @@ const FileDropperControl = require("../controls/file_dropper_control.js");
 const template = views.getTemplate("post-upload");
 const rowTemplate = views.getTemplate("post-upload-row");
 
+const misc = require('../util/misc.js');
+const TagAutoCompleteControl =
+    require('../controls/tag_auto_complete_control.js');
+
 function _mimeTypeToPostType(mimeType) {
     return (
         {
@@ -183,6 +187,16 @@ class PostUploadView extends events.EventTarget {
             this._evtFormSubmit(e)
         );
         this._formNode.classList.add("inactive");
+
+        if (this._commonTagsInputNode) {
+            this._autoCompleteControl = new TagAutoCompleteControl(
+                this._commonTagsInputNode,
+                {
+                    confirm: tag =>
+                        this._autoCompleteControl.replaceSelectedText(
+                            misc.escapeSearchTerm(tag.names[0]), true),
+                });
+        }    
     }
 
     enableForm() {
@@ -305,6 +319,12 @@ class PostUploadView extends events.EventTarget {
         }
 
         uploadable.tags = [];
+        if (this._commonTagsInputNode) {
+            var tags = this._commonTagsInputNode.value.split(' ');
+            tags = tags.filter(t => t != "");
+            uploadable.tags = uploadable.tags.concat(tags);
+        }
+        
         uploadable.relations = [];
         for (let [i, lookalike] of uploadable.lookalikes.entries()) {
             let lookalikeNode = rowNode.querySelector(
@@ -449,6 +469,10 @@ class PostUploadView extends events.EventTarget {
 
     get _contentInputNode() {
         return this._formNode.querySelector(".dropper-container");
+    }
+
+    get _commonTagsInputNode() {
+        return this._formNode.querySelector('form [name=common-tags');
     }
 }
 


### PR DESCRIPTION
This cherrypicks @Hunternif's https://github.com/hunternif/szurubooru/commit/035ce19788626c007619c004ef3b702f70ac262e commit to add common tags to uploads.

Relates to #382, although it does not implement mass safety changing.

Again, almost all credit goes to @Hunternif for the actual implementation.