### PR TITLE
docs:Fix external link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Szurubooru is an image board engine inspired by services such as Danbooru,
 Gelbooru and Moebooru dedicated for small and medium communities. Its name [has
 its roots in Polish language and has onomatopeic meaning of scraping or
-scrubbing](http://sjp.pwn.pl/sjp/;2527372). It is pronounced as *shoorubooru*.
+scrubbing](https://sjp.pwn.pl/sjp/;2527372). It is pronounced as *shoorubooru*.
 
 ## Features
 


### PR DESCRIPTION
Fixed an external link in `README.md` redirecting users to 400 error page upon their first visit of `sjp.pwn.pl`