### PR TITLE
doc: add GET /post/<id>/around to API.md

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -37,6 +37,7 @@
         - [Creating post](#creating-post)
         - [Updating post](#updating-post)
         - [Getting post](#getting-post)
+        - [Getting around post](#getting-around-post)
         - [Deleting post](#deleting-post)
         - [Merging posts](#merging-posts)
         - [Rating post](#rating-post)
@@ -950,6 +951,29 @@ data.
 - **Description**
 
     Retrieves information about an existing post.
+
+## Getting around post
+- **Request**
+
+    `GET /post/<id>/around`
+
+- **Output**
+
+    ```json5
+    {
+        "prev":  <post-resource>,
+        "next":  <post-resource>
+    }
+    ```
+
+- **Errors**
+
+    - the post does not exist
+    - privileges are too low
+
+- **Description**
+
+    Retrieves information about posts that are before or after an existing post.
 
 ## Deleting post
 - **Request**


### PR DESCRIPTION
While taking a look at szurubooru's code I noticed that `/post/<id>/around` is not documented, even though it is part of the API used by the frontend to power the previous/next post cursor.