### PR TITLE
Default upload tags and anonymous uploads

### DIFF
--- a/client/css/post-upload.styl
+++ b/client/css/post-upload.styl
@@ -15,6 +15,7 @@ $cancel-button-color = tomato
         &.inactive .skip-duplicates
         &.inactive .always-upload-similar
         &.inactive .pause-remain-on-error
+        &.inactive #common-tags,
         &.uploading input[type=submit],
         &.uploading .skip-duplicates,
         &.uploading .always-upload-similar
@@ -29,6 +30,9 @@ $cancel-button-color = tomato
             padding: 2em
             small
                 font-size: 60%
+
+    label[for=common-tags]
+        display: none !important
 
     input[type=submit]
         margin-top: 1em

--- a/client/css/post-upload.styl
+++ b/client/css/post-upload.styl
@@ -15,11 +15,13 @@ $cancel-button-color = tomato
         &.inactive .skip-duplicates
         &.inactive .always-upload-similar
         &.inactive .pause-remain-on-error
+        &.inactive .upload-all-anonymous
         &.inactive #common-tags,
         &.uploading input[type=submit],
         &.uploading .skip-duplicates,
         &.uploading .always-upload-similar
         &.uploading .pause-remain-on-error
+        &.uploading .upload-all-anonymous
         &:not(.uploading) .cancel
             display: none
 
@@ -58,6 +60,15 @@ $cancel-button-color = tomato
 
     form>.messages
         margin-top: 1em
+
+    .control-strip
+        display: flex
+        flex-direction: column
+        gap: 0.5em
+
+    .control-options
+        display: flex
+        flex-direction: column
 
     .uploadables-container
         list-style-type: none

--- a/client/css/post-upload.styl
+++ b/client/css/post-upload.styl
@@ -53,6 +53,9 @@ $cancel-button-color = tomato
     .pause-remain-on-error
         margin-left: 1em
 
+    .upload-all-anonymous
+        margin-left: 1em
+
     form>.messages
         margin-top: 1em
 

--- a/client/html/post_upload.tpl
+++ b/client/html/post_upload.tpl
@@ -29,6 +29,8 @@
                 }) %>
             </span>
 
+            <%= ctx.makeTextInput({placeholder: 'Common tags', id: 'common-tags', name: 'common-tags', style: 'margin-top:1em;'}) %>
+
             <input type='button' value='Cancel' class='cancel'/>
         </div>
 

--- a/client/html/post_upload.tpl
+++ b/client/html/post_upload.tpl
@@ -29,6 +29,14 @@
                 }) %>
             </span>
 
+            <span class='upload-all-anonymous'>
+                <%= ctx.makeCheckbox({
+                    text: 'Upload anonymously',
+                    name: 'upload-all-anonymous',
+                    checked: false,
+                }) %>
+            </span>
+
             <%= ctx.makeTextInput({placeholder: 'Common tags', id: 'common-tags', name: 'common-tags', style: 'margin-top:1em;'}) %>
 
             <input type='button' value='Cancel' class='cancel'/>

--- a/client/html/post_upload.tpl
+++ b/client/html/post_upload.tpl
@@ -5,39 +5,41 @@
         <div class='control-strip'>
             <input type='submit' value='Upload all' class='submit'/>
 
-            <span class='skip-duplicates'>
-                <%= ctx.makeCheckbox({
-                    text: 'Skip duplicate',
-                    name: 'skip-duplicates',
-                    checked: false,
-                }) %>
-            </span>
+            <div class='control-options'>
+                <span class='skip-duplicates'>
+                    <%= ctx.makeCheckbox({
+                        text: 'Skip duplicate',
+                        name: 'skip-duplicates',
+                        checked: false,
+                    }) %>
+                </span>
 
-            <span class='always-upload-similar'>
-                <%= ctx.makeCheckbox({
-                    text: 'Force upload similar',
-                    name: 'always-upload-similar',
-                    checked: false,
-                }) %>
-            </span>
+                <span class='always-upload-similar'>
+                    <%= ctx.makeCheckbox({
+                        text: 'Force upload similar',
+                        name: 'always-upload-similar',
+                        checked: false,
+                    }) %>
+                </span>
 
-            <span class='pause-remain-on-error'>
-                <%= ctx.makeCheckbox({
-                    text: 'Pause on error',
-                    name: 'pause-remain-on-error',
-                    checked: true,
-                }) %>
-            </span>
+                <span class='pause-remain-on-error'>
+                    <%= ctx.makeCheckbox({
+                        text: 'Pause on error',
+                        name: 'pause-remain-on-error',
+                        checked: true,
+                    }) %>
+                </span>
 
-            <span class='upload-all-anonymous'>
-                <%= ctx.makeCheckbox({
-                    text: 'Upload anonymously',
-                    name: 'upload-all-anonymous',
-                    checked: false,
-                }) %>
-            </span>
+                <span class='upload-all-anonymous'>
+                    <%= ctx.makeCheckbox({
+                        text: 'Upload anonymously',
+                        name: 'upload-all-anonymous',
+                        checked: false,
+                    }) %>
+                </span>
+            </div>
 
-            <%= ctx.makeTextInput({placeholder: 'Common tags', id: 'common-tags', name: 'common-tags', style: 'margin-top:1em;'}) %>
+            <%= ctx.makeTextInput({placeholder: 'Common tags', id: 'common-tags', name: 'common-tags'}) %>
 
             <input type='button' value='Cancel' class='cancel'/>
         </div>

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -474,7 +474,7 @@ class PostUploadView extends events.EventTarget {
     }
 
     get _commonTagsInputNode() {
-        return this._formNode.querySelector('form [name=common-tags');
+        return this._formNode.querySelector('form [name=common-tags]');
     }
 }
 

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -8,6 +8,10 @@ const FileDropperControl = require("../controls/file_dropper_control.js");
 const template = views.getTemplate("post-upload");
 const rowTemplate = views.getTemplate("post-upload-row");
 
+const misc = require('../util/misc.js');
+const TagAutoCompleteControl =
+    require('../controls/tag_auto_complete_control.js');
+
 function _mimeTypeToPostType(mimeType) {
     return (
         {
@@ -183,6 +187,16 @@ class PostUploadView extends events.EventTarget {
             this._evtFormSubmit(e)
         );
         this._formNode.classList.add("inactive");
+
+        if (this._commonTagsInputNode) {
+            this._autoCompleteControl = new TagAutoCompleteControl(
+                this._commonTagsInputNode,
+                {
+                    confirm: tag =>
+                        this._autoCompleteControl.replaceSelectedText(
+                            misc.escapeSearchTerm(tag.names[0]), true),
+                });
+        }
     }
 
     enableForm() {
@@ -305,6 +319,11 @@ class PostUploadView extends events.EventTarget {
         }
 
         uploadable.tags = [];
+        if (this._commonTagsInputNode) {
+            var tags = this._commonTagsInputNode.value.split(' ');
+            tags = tags.filter(t => t != "");
+            uploadable.tags = uploadable.tags.concat(tags);
+        }
         uploadable.relations = [];
         for (let [i, lookalike] of uploadable.lookalikes.entries()) {
             let lookalikeNode = rowNode.querySelector(
@@ -449,6 +468,10 @@ class PostUploadView extends events.EventTarget {
 
     get _contentInputNode() {
         return this._formNode.querySelector(".dropper-container");
+    }
+
+    get _commonTagsInputNode() {
+        return this._formNode.querySelector('form [name=common-tags');
     }
 }
 

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -320,7 +320,7 @@ class PostUploadView extends events.EventTarget {
         uploadable.tags = [];
         if (this._commonTagsInputNode) {
             var tags = this._commonTagsInputNode.value.split(' ');
-            tags = tags.filter(t => t != "");
+            tags = tags.filter(t => t != "").map(t => t.replace('\\', ''));
             uploadable.tags = uploadable.tags.concat(tags);
         }
         uploadable.relations = [];

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -311,12 +311,11 @@ class PostUploadView extends events.EventTarget {
             uploadable.safety = safetyNode.value;
         }
 
-        const anonymousNode = rowNode.querySelector(
-            ".anonymous input:checked"
-        );
-        if (anonymousNode) {
-            uploadable.anonymous = true;
+        let anonymous = this._uploadAllAnonymous?.checked;
+        if (!anonymous) {
+            anonymous = rowNode.querySelector(".anonymous input:checked");
         }
+        uploadable.anonymous = anonymous;
 
         uploadable.tags = [];
         if (this._commonTagsInputNode) {
@@ -456,6 +455,10 @@ class PostUploadView extends events.EventTarget {
         return this._hostNode.querySelector(
             "form [name=pause-remain-on-error]"
         );
+    }
+
+    get _uploadAllAnonymous() {
+        return this._hostNode.querySelector("form [name=upload-all-anonymous]");
     }
 
     get _submitButtonNode() {

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -311,7 +311,7 @@ class PostUploadView extends events.EventTarget {
             uploadable.safety = safetyNode.value;
         }
 
-        let anonymous = this._uploadAllAnonymous?.checked;
+        let anonymous = this._uploadAllAnonymous.checked;
         if (!anonymous) {
             anonymous = rowNode.querySelector(".anonymous input:checked");
         }


### PR DESCRIPTION
Hello,

I've taken the cherry-pick from [noirscape](https://github.com/noirscape)'s #468 , which was made by https://github.com/Hunternif/szurubooru/commit/035ce19788626c007619c004ef3b702f70ac262e and merged + tested it on my local environment, fixing an issue with tag name escaping as well.

Additionally, I added an option to mass upload posts anonymously, since if you are uploading a big mass of images it's annoying to mark all posts individually as anonymous. Due to there now being 4 checkboxes on the page, I've taken a bit of time to redesign the layout so it fits better.

![image](https://user-images.githubusercontent.com/7545720/210095534-e02331ac-bcc3-47f3-81f4-4fbf4614171a.png)

These changes affect only the frontend and have all been tested on a local instance.