### PR TITLE
Fix post flow view on webkit browsers

### DIFF
--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -300,10 +300,10 @@ a .access-key
         background-size: 20px 20px
     img
         opacity: 0
-        width: 100%
+        width: auto
         height: 100%
     video
-        width: 100%
+        width: auto
         height: 100%
 
 .flexbox-dummy


### PR DESCRIPTION
Post flow view seems to set the width of images on webkit browsers to be much wider than intended.

Before:
![before](https://user-images.githubusercontent.com/7002074/224819876-40e51a10-7db3-404f-9991-1796a1cb0564.jpg)
After:
![after](https://user-images.githubusercontent.com/7002074/224819890-e04611ba-1b3e-407c-9fe7-36160bbd72b3.jpg)
