### PR TITLE
docs (api): change micro post attribute name to id

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -2491,7 +2491,7 @@ One file together with its metadata posted to the site.
 ## Micro post
 **Description**
 
-A [post resource](#post) stripped down to `name` and `thumbnailUrl` fields.
+A [post resource](#post) stripped down to `id` and `thumbnailUrl` fields.
 
 ## Note
 **Description**

--- a/doc/API.md
+++ b/doc/API.md
@@ -323,7 +323,7 @@ data.
     {
         "name":  <name>,
         "color": <color>,
-        "order": <order>  // optional
+        "order": <order>
     }
     ```
 


### PR DESCRIPTION
The API documentation says a micro post contains the fields  "name" and "thumbnailUrl", which is wrong. Instead of "name", it should be "id".