### PR TITLE
Allow to change backend port for the client.

### DIFF
--- a/client/docker-start.sh
+++ b/client/docker-start.sh
@@ -3,6 +3,8 @@
 # Integrate environment variables
 sed -i "s|__BACKEND__|${BACKEND_HOST}|" \
     /etc/nginx/nginx.conf
+sed -i "s|__BACKEND_PORT__|${BACKEND_PORT}|" \
+    /etc/nginx/nginx.conf
 sed -i "s|__BASEURL__|${BASE_URL:-/}|g" \
     /var/www/index.htm \
     /var/www/manifest.json

--- a/client/nginx.conf.docker
+++ b/client/nginx.conf.docker
@@ -20,7 +20,7 @@ http {
     keepalive_timeout 65;
 
     upstream backend {
-        server __BACKEND__:6666;
+        server __BACKEND__:__BACKEND_PORT__;
     }
 
     server {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - server
     environment:
       BACKEND_HOST: server
+      BACKEND_PORT: 6666
       BASE_URL:
     volumes:
       - "${MOUNT_DATA}:/data:ro"


### PR DESCRIPTION
I've tried to install szurubooru on TrueNAS. It works under Kubernetes. And it has limitation — it disallows usage of ports <= 9000.

So, to allow usage under Kubernetes and at some security restricted systems i propose to allow port selection for the client.

As for now it hardcoded to 6666. And i propose to replace it with sed like server address.