### PR TITLE
Added suggests/implies named tokens for tag search

### DIFF
--- a/client/html/help_search_tags.tpl
+++ b/client/html/help_search_tags.tpl
@@ -51,6 +51,22 @@
             <td>alias of <code>usages</code></td>
         </tr>
         <tr>
+            <td><code>suggests</code></td>
+            <td>with given suggested tags (accepts wildcards)</td>
+        </tr>
+        <tr>
+            <td><code>implies</code></td>
+            <td>with given implied tags (accepts wildcards)</td>
+        </tr>
+        <tr>
+            <td><code>suggested-by</code></td>
+            <td>suggested by given tags (accepts wildcards)</td>
+        </tr>
+        <tr>
+            <td><code>implied-by</code></td>
+            <td>implied by given tags (accepts wildcards)</td>
+        </tr>
+        <tr>
             <td><code>suggestion-count</code></td>
             <td>with given number of suggestions</td>
         </tr>

--- a/server/szurubooru/search/configs/tag_search_config.py
+++ b/server/szurubooru/search/configs/tag_search_config.py
@@ -96,6 +96,50 @@ class TagSearchConfig(BaseSearchConfig):
                     ["implication-count"],
                     search_util.create_num_filter(model.Tag.implication_count),
                 ),
+                (
+                    ["suggested-by"],
+                    search_util.create_nested_filter(
+                        model.Tag.tag_id,
+                        model.TagSuggestion.child_id,
+                        model.TagSuggestion.parent_id,
+                        model.TagName.tag_id,
+                        model.TagName.name,
+                        search_util.create_str_filter,
+                    ),
+                ),
+                (
+                    ["suggests"],
+                    search_util.create_nested_filter(
+                        model.Tag.tag_id,
+                        model.TagSuggestion.parent_id,
+                        model.TagSuggestion.child_id,
+                        model.TagName.tag_id,
+                        model.TagName.name,
+                        search_util.create_str_filter,
+                    ),
+                ),
+                (
+                    ["implied-by"],
+                    search_util.create_nested_filter(
+                        model.Tag.tag_id,
+                        model.TagImplication.child_id,
+                        model.TagImplication.parent_id,
+                        model.TagName.tag_id,
+                        model.TagName.name,
+                        search_util.create_str_filter,
+                    ),
+                ),
+                (
+                    ["implies"],
+                    search_util.create_nested_filter(
+                        model.Tag.tag_id,
+                        model.TagImplication.parent_id,
+                        model.TagImplication.child_id,
+                        model.TagName.tag_id,
+                        model.TagName.name,
+                        search_util.create_str_filter,
+                    ),
+                ),
             ]
         )
 

--- a/server/szurubooru/tests/search/configs/test_tag_search_config.py
+++ b/server/szurubooru/tests/search/configs/test_tag_search_config.py
@@ -373,6 +373,120 @@ def test_filter_by_implication_count(
 @pytest.mark.parametrize(
     "input,expected_tag_names",
     [
+        ("suggests:sug1", ["t1", "t3"]),
+        ("suggests:sug2", ["t1"]),
+        ("suggests:sug3", ["t2"]),
+        ("suggests:t1", []),
+        ("-suggests:sug1", ["sug1", "sug2", "sug3", "t2"]),
+    ],
+)
+def test_filter_by_suggests_tags(
+    verify_unpaged, tag_factory, input, expected_tag_names
+):
+    sug1 = tag_factory(names=["sug1"])
+    sug2 = tag_factory(names=["sug2"])
+    sug3 = tag_factory(names=["sug3"])
+    tag1 = tag_factory(names=["t1"])
+    tag2 = tag_factory(names=["t2"])
+    tag3 = tag_factory(names=["t3"])
+    db.session.add_all([sug1, sug3, tag2, sug2, tag1, tag3])
+    tag1.suggestions.append(sug1)
+    tag1.suggestions.append(sug2)
+    tag2.suggestions.append(sug3)
+    tag3.suggestions.append(sug1)
+    db.session.flush()
+    verify_unpaged(input, expected_tag_names)
+
+
+@pytest.mark.parametrize(
+    "input,expected_tag_names",
+    [
+        ("suggested-by:t1", ["sug1", "sug2"]),
+        ("suggested-by:t2", ["sug3"]),
+        ("suggested-by:t3", ["sug4", "t2"]),
+        ("-suggested-by:t3", ["sug1", "sug2", "sug3", "t1", "t3",]),
+    ],
+)
+def test_filter_by_suggests_by_tags(
+    verify_unpaged, tag_factory, input, expected_tag_names
+):
+    sug1 = tag_factory(names=["sug1"])
+    sug2 = tag_factory(names=["sug2"])
+    sug3 = tag_factory(names=["sug3"])
+    sug4 = tag_factory(names=["sug4"])
+    tag1 = tag_factory(names=["t1"])
+    tag2 = tag_factory(names=["t2"])
+    tag3 = tag_factory(names=["t3"])
+    db.session.add_all([sug1, sug3, tag2, sug2, tag1, tag3, sug4])
+    tag1.suggestions.append(sug1)
+    tag1.suggestions.append(sug2)
+    tag2.suggestions.append(sug3)
+    tag3.suggestions.append(tag2)
+    tag3.suggestions.append(sug4)
+    db.session.flush()
+    verify_unpaged(input, expected_tag_names)
+
+
+@pytest.mark.parametrize(
+    "input,expected_tag_names",
+    [
+        ("implies:sug1", ["t1", "t3"]),
+        ("implies:sug2", ["t1"]),
+        ("implies:sug3", ["t2"]),
+        ("implies:t1", []),
+        ("-implies:sug1", ["sug1", "sug2", "sug3", "t2"]),
+    ],
+)
+def test_filter_by_implies_tags(
+    verify_unpaged, tag_factory, input, expected_tag_names
+):
+    sug1 = tag_factory(names=["sug1"])
+    sug2 = tag_factory(names=["sug2"])
+    sug3 = tag_factory(names=["sug3"])
+    tag1 = tag_factory(names=["t1"])
+    tag2 = tag_factory(names=["t2"])
+    tag3 = tag_factory(names=["t3"])
+    db.session.add_all([sug1, sug3, tag2, sug2, tag1, tag3])
+    tag1.implications.append(sug1)
+    tag1.implications.append(sug2)
+    tag2.implications.append(sug3)
+    tag3.implications.append(sug1)
+    db.session.flush()
+    verify_unpaged(input, expected_tag_names)
+
+
+@pytest.mark.parametrize(
+    "input,expected_tag_names",
+    [
+        ("implied-by:t1", ["sug1", "sug2"]),
+        ("implied-by:t2", ["sug3"]),
+        ("implied-by:t3", ["sug4", "t2",]),
+        ("-implied-by:t3", ["sug1", "sug2", "sug3", "t1", "t3",]),
+    ],
+)
+def test_filter_by_implied_by_tags(
+    verify_unpaged, tag_factory, input, expected_tag_names
+):
+    sug1 = tag_factory(names=["sug1"])
+    sug2 = tag_factory(names=["sug2"])
+    sug3 = tag_factory(names=["sug3"])
+    sug4 = tag_factory(names=["sug4"])
+    tag1 = tag_factory(names=["t1"])
+    tag2 = tag_factory(names=["t2"])
+    tag3 = tag_factory(names=["t3"])
+    db.session.add_all([sug1, sug3, tag2, sug2, tag1, tag3, sug4])
+    tag1.implications.append(sug1)
+    tag1.implications.append(sug2)
+    tag2.implications.append(sug3)
+    tag3.implications.append(tag2)
+    tag3.implications.append(sug4)
+    db.session.flush()
+    verify_unpaged(input, expected_tag_names)
+
+
+@pytest.mark.parametrize(
+    "input,expected_tag_names",
+    [
         ("", ["t1", "t2"]),
         ("sort:name", ["t1", "t2"]),
         ("-sort:name", ["t2", "t1"]),


### PR DESCRIPTION
Added the ability to search for tags by the tags they imply or suggest.

![image](https://github.com/rr-/szurubooru/assets/31100258/fb09f16e-8efc-4abd-8c35-ed62650d15e8)

Also added the inverse, i.e., searching for tags by the tags they are implied by or suggested by. This is mostly only useful when combining queries.

![image](https://github.com/rr-/szurubooru/assets/31100258/1d66a621-b3a7-4261-85f4-5a147e0bc4af)

I’ve been using these for a while, maybe someone else finds them useful as well.