### PR TITLE
Add ability to configure allowed file types

### DIFF
--- a/client/js/api.js
+++ b/client/js/api.js
@@ -100,6 +100,10 @@ class Api extends events.EventTarget {
         return remoteConfig.contactEmail;
     }
 
+    getAllowedExtensions() {
+    	return remoteConfig.allowedExtensions;
+    }
+
     canSendMails() {
         return !!remoteConfig.canSendMails;
     }

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -161,11 +161,14 @@ class PostUploadView extends events.EventTarget {
             return this._uploadables.findIndex((u2) => u.key === u2.key);
         };
 
+				let allowedExtensions = api.getAllowedExtensions().map(
+					function(e) {return "." + e}
+				);
         this._contentFileDropper = new FileDropperControl(
             this._contentInputNode,
             {
                 extraText:
-                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic",
+                    "Allowed extensions: " + allowedExtensions.join(", "),
                 allowUrls: true,
                 allowMultiple: true,
                 lock: false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '2'
 services:
 
   server:
-    image: szurubooru/server:latest
+    build: server
     depends_on:
       - sql
     environment:
@@ -27,7 +27,7 @@ services:
       - "./server/config.yaml:/opt/app/config.yaml"
 
   client:
-    image: szurubooru/client:latest
+    build: client
     depends_on:
       - server
     environment:

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -29,6 +29,18 @@ convert:
      to_webm: false
      to_mp4: false
 
+# specify which MIME types are allowed
+allowed_mime_types:
+   - image/jpeg
+   - image/png
+   - image/gif
+   - video/webm
+   - video/mp4
+   - application/x-shockwave-flash
+   - image/avif
+   - image/heif
+   - image/heic
+
 # allow posts to be uploaded even if some image processing errors occur
 allow_broken_uploads: false
 

--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import Dict, Optional
 
 from szurubooru import config, rest
-from szurubooru.func import auth, posts, users, util
+from szurubooru.func import auth, mime, posts, users, util
 
 _cache_time = None  # type: Optional[datetime]
 _cache_result = None  # type: Optional[int]
@@ -49,6 +49,11 @@ def get_info(ctx: rest.Context, _params: Dict[str, str] = {}) -> rest.Response:
             "privileges": util.snake_case_to_lower_camel_case_keys(
                 config.config["privileges"]
             ),
+            "allowedExtensions": [
+                mime.MIME_EXTENSIONS_MAP[i]
+                for i in config.config["allowed_mime_types"]
+                if i in mime.MIME_EXTENSIONS_MAP
+            ],
         },
     }
     if auth.has_privilege(ctx.user, "posts:view:featured"):

--- a/server/szurubooru/func/mime.py
+++ b/server/szurubooru/func/mime.py
@@ -1,5 +1,32 @@
 import re
+from collections import ChainMap
 from typing import Optional
+
+MIME_TYPES_MAP = {
+    "image": {
+        "image/gif": "gif",
+        "image/jpeg": "jpg",
+        "image/png": "png",
+        "image/webp": "webp",
+        "image/bmp": "bmp",
+        "image/avif": "avif",
+        "image/heif": "heif",
+        "image/heic": "heic",
+    },
+    "video": {
+        "application/ogg": None,
+        "video/mp4": "mp4",
+        "video/quicktime": "mov",
+        "video/webm": "webm",
+    },
+    "flash": {
+        "application/x-shockwave-flash": "swf"
+    },
+    "other": {
+        "application/octet-stream": "dat",
+    },
+}
+MIME_EXTENSIONS_MAP = ChainMap(*MIME_TYPES_MAP.values())
 
 
 def get_mime_type(content: bytes) -> str:
@@ -46,48 +73,19 @@ def get_mime_type(content: bytes) -> str:
 
 
 def get_extension(mime_type: str) -> Optional[str]:
-    extension_map = {
-        "application/x-shockwave-flash": "swf",
-        "image/gif": "gif",
-        "image/jpeg": "jpg",
-        "image/png": "png",
-        "image/webp": "webp",
-        "image/bmp": "bmp",
-        "image/avif": "avif",
-        "image/heif": "heif",
-        "image/heic": "heic",
-        "video/mp4": "mp4",
-        "video/quicktime": "mov",
-        "video/webm": "webm",
-        "application/octet-stream": "dat",
-    }
-    return extension_map.get((mime_type or "").strip().lower(), None)
+    return MIME_EXTENSIONS_MAP.get((mime_type or "").strip().lower(), None)
 
 
 def is_flash(mime_type: str) -> bool:
-    return mime_type.lower() == "application/x-shockwave-flash"
+    return mime_type.lower() in MIME_TYPES_MAP["flash"]
 
 
 def is_video(mime_type: str) -> bool:
-    return mime_type.lower() in (
-        "application/ogg",
-        "video/mp4",
-        "video/quicktime",
-        "video/webm",
-    )
+    return mime_type.lower() in MIME_TYPES_MAP["video"]
 
 
 def is_image(mime_type: str) -> bool:
-    return mime_type.lower() in (
-        "image/jpeg",
-        "image/png",
-        "image/gif",
-        "image/webp",
-        "image/bmp",
-        "image/avif",
-        "image/heif",
-        "image/heic",
-    )
+    return mime_type.lower() in MIME_TYPES_MAP["image"]
 
 
 def is_animated_gif(content: bytes) -> bool:

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -611,7 +611,11 @@ def update_post_content(post: model.Post, content: Optional[bytes]) -> None:
 
     update_signature = False
     post.mime_type = mime.get_mime_type(content)
-    if mime.is_flash(post.mime_type):
+    if post.mime_type not in config.config["allowed_mime_types"]:
+        raise InvalidPostContentError(
+            "File type not allowed: %r" % post.mime_type
+        )
+    elif mime.is_flash(post.mime_type):
         post.type = model.Post.TYPE_FLASH
     elif mime.is_image(post.mime_type):
         update_signature = True

--- a/server/szurubooru/tests/api/test_info.py
+++ b/server/szurubooru/tests/api/test_info.py
@@ -34,6 +34,7 @@ def test_info_api(
             "smtp": {
                 "host": "example.com",
             },
+            "allowed_mime_types": ["application/octet-stream"],
         }
     )
     db.session.add_all([post_factory(), post_factory()])
@@ -54,6 +55,7 @@ def test_info_api(
             "posts:view:featured": "regular",
         },
         "canSendMails": True,
+        "allowedExtensions": ["dat"],
     }
 
     with fake_datetime("2016-01-01 13:00"):

--- a/server/szurubooru/tests/api/test_post_creating.py
+++ b/server/szurubooru/tests/api/test_post_creating.py
@@ -343,6 +343,10 @@ def test_errors_not_spending_ids(
                 "uploads:use_downloader": model.User.RANK_POWER,
             },
             "secret": "test",
+            "allowed_mime_types": [
+                "image/png",
+                "image/jpeg",
+            ],
         }
     )
     auth_user = user_factory(rank=model.User.RANK_REGULAR)


### PR DESCRIPTION
This PR adds ability to configure allowed file types via `config.yaml` file. I went for using MIME types identifiers rather than extensions because it maps better to existing file type handling in szurubooru. The files that are of unallowed types are rejected with `szuruburu.func.posts.InvalidPostContentError`, same as with unsupported files but with different error message.