### PR TITLE
server/net: use yt-dlp instead of youtube-dl

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ scrubbing](https://sjp.pwn.pl/sjp/;2527372). It is pronounced as *shoorubooru*.
 ## Features
 
 - Post content: images (JPG, PNG, GIF, animated GIF), videos (MP4, WEBM), Flash animations
-- Ability to retrieve web video content using [youtube-dl](https://github.com/ytdl-org/youtube-dl)
+- Ability to retrieve web video content using [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 - Post comments
 - Post notes / annotations, including arbitrary polygons
 - Rich JSON REST API ([see documentation](doc/API.md))

--- a/doc/API.md
+++ b/doc/API.md
@@ -165,9 +165,9 @@ way. The files, however, should be passed as regular fields appended with a
 accepts a file named `content`, the client should pass
 `{"contentUrl":"http://example.com/file.jpg"}` as a part of the JSON message
 body. When creating or updating post content using this method, the server can
-also be configured to employ [youtube-dl](https://github.com/ytdl-org/youtube-dl)
-to download content from popular sites such as youtube, gfycat, etc. Access to
-youtube-dl can be configured with the `'uploads:use_downloader'` permission
+also be configured to employ [yt-dlp](https://github.com/yt-dlp/yt-dlp) to
+download content from popular sites such as youtube, gfycat, etc. Access to
+yt-dlp can be configured with the `'uploads:use_downloader'` permission
 
 Finally, in some cases the user might want to reuse one file between the
 requests to save the bandwidth (for example, reverse search + consecutive

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -29,7 +29,7 @@ RUN apk --no-cache add \
         "coloredlogs==5.0" \
         "pyheif==0.6.1" \
         "heif-image-plugin>=0.3.2" \
-        youtube_dl \
+        yt-dlp \
         "pillow-avif-plugin>=1.1.0" \
  && apk --no-cache del py3-pip
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,4 +12,4 @@ pyRFC3339>=1.0
 pytz>=2018.3
 pyyaml>=3.11
 SQLAlchemy>=1.0.12, <1.4
-youtube_dl
+yt-dlp

--- a/server/szurubooru/func/net.py
+++ b/server/szurubooru/func/net.py
@@ -64,7 +64,7 @@ def download(url: str, use_video_downloader: bool = False) -> bytes:
 
 
 def _get_youtube_dl_content_url(url: str) -> str:
-    cmd = ["youtube-dl", "--format", "best", "--no-playlist"]
+    cmd = ["yt-dlp", "--format", "best", "--no-playlist"]
     if config.config["user_agent"]:
         cmd.extend(["--user-agent", config.config["user_agent"]])
     cmd.extend(["--get-url", url])


### PR DESCRIPTION
youtube-dl no longer even gets URLs properly:

```
⌁ [zakame:~/src/szurubooru] use-yt-dlp(1) 4s ± docker run --rm -it szurubooru/server:2.5 sh                                                                
Unable to find image 'szurubooru/server:2.5' locally
2.5: Pulling from szurubooru/server
Digest: sha256:4fa5bc78cc0c44632085adea92639346a151c8cc3023abbc0beb52f0f178f778
Status: Downloaded newer image for szurubooru/server:2.5
~ $ youtube-dl --version
2021.12.17
~ $ youtube-dl --format best --no-playlist --get-url https://www.youtube.com/watch?v=dQw4w9WgXcQ
ERROR: Unable to extract uploader id; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

so switch to yt-dlp as a drop-in replacement for it:

```
⌁ [zakame:~/src/szurubooru] use-yt-dlp(1) 3m59s 130 ± yt-dlp --format best --no-playlist --get-url https://www.youtube.com/watch\?v\=dQw4w9WgXcQ
WARNING: "-f best" selects the best pre-merged format which is often not the best option.
         To let yt-dlp download and merge the best available formats, simply do not pass any format selection.
         If you know what you are doing and want only the best pre-merged format, use "-f b" instead to suppress this warning
https://rr2---sn-2aqu-hoalr.googlevideo.com/videoplayback?expire=XXXX&yyyy=this+is+not+a+real+video+link
```