### PR TITLE
Respect EXIF orientation

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,6 +13,7 @@ RUN apk --no-cache add \
         libheif-dev \
         libavif \
         libavif-dev \
+        exiftool \
         ffmpeg \
         # from requirements.txt:
         py3-yaml \


### PR DESCRIPTION
This PR checks EXIF orientation. Addresses #470.

### Method
Calls to ffprobe are replaced with exiftool (supported file formats: https://exiftool.org/TagNames/)
exiftool is capable of getting the metadata we want for static images and video, and gives us access to an image's Orientation.

### Alternative
This branch is heavily inspired by skybldev's work here: https://github.com/rr-/szurubooru/pull/499.
Differences:
 * This PR has a smaller scope - only orientation is checked, no other features are added.
 * skybldev's fork uses the exif python library alongside ffprobe. This PR uses only exiftool.

### Limitations
* This PR is still missing a migration to regenerate existing images + thumbnails.
* This PR is still missing unit tests for EXIF images.