### PR TITLE
Posts page ugly horizontal bar fix.

### DIFF
--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -300,10 +300,10 @@ a .access-key
         background-size: 20px 20px
     img
         opacity: 0
-        width: auto
+        width: 100%
         height: 100%
     video
-        width: auto
+        width: 100%
         height: 100%
 
 .flexbox-dummy


### PR DESCRIPTION
Fixes ugly scrollbar appearing on the posts page when a post with extremely wide image/video is present in the list.

Before:
![изображение](https://github.com/rr-/szurubooru/assets/16465620/3c2eb24a-b954-4023-86db-c798d7d95533)

After:
![изображение](https://github.com/rr-/szurubooru/assets/16465620/e103d985-d24f-4dac-a80b-8527e688f527)
