### PR TITLE
Adding option to disable the _get_disk_usage

### DIFF
--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -177,3 +177,9 @@ privileges:
 ## usage: schema://user:password@host:port/database_name
 ## example: postgres://szuru:dog@localhost:5432/szuru_test
 #database:
+
+
+## get the data dir usage
+## 0 disabled 
+## 1 enabled ( default )
+data_dir_get_usage: 1

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -180,6 +180,6 @@ privileges:
 
 
 ## get the data dir usage
-## 0 disabled 
-## 1 enabled ( default )
-data_dir_get_usage: 1
+## false disabled 
+## true enabled ( default )
+data_dir_get_usage: true

--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -11,7 +11,7 @@ _cache_result = None  # type: Optional[int]
 
 def _get_disk_usage() -> int:
     total_size = 0
-    if config.config["data_dir_get_usage"] == 1:
+    if config.config["data_dir_get_usage"]:
         global _cache_time, _cache_result
         threshold = timedelta(hours=48)
         now = datetime.utcnow()

--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -10,22 +10,23 @@ _cache_result = None  # type: Optional[int]
 
 
 def _get_disk_usage() -> int:
-    global _cache_time, _cache_result
-    threshold = timedelta(hours=48)
-    now = datetime.utcnow()
-    if _cache_time and _cache_time > now - threshold:
-        assert _cache_result is not None
-        return _cache_result
     total_size = 0
-    for dir_path, _, file_names in os.walk(config.config["data_dir"]):
-        for file_name in file_names:
-            file_path = os.path.join(dir_path, file_name)
-            try:
-                total_size += os.path.getsize(file_path)
-            except FileNotFoundError:
-                pass
-    _cache_time = now
-    _cache_result = total_size
+    if config.config["data_dir_get_usage"] == 1:
+        global _cache_time, _cache_result
+        threshold = timedelta(hours=48)
+        now = datetime.utcnow()
+        if _cache_time and _cache_time > now - threshold:
+            assert _cache_result is not None
+            return _cache_result
+        for dir_path, _, file_names in os.walk(config.config["data_dir"]):
+            for file_name in file_names:
+                file_path = os.path.join(dir_path, file_name)
+                try:
+                    total_size += os.path.getsize(file_path)
+                except FileNotFoundError:
+                    pass
+        _cache_time = now
+        _cache_result = total_size
     return total_size
 
 


### PR DESCRIPTION
It's solving this issue #449 in https://github.com/rr-/szurubooru/issues/449#issuecomment-1416593833

I've added the configuration part and the python part to disable the function (_get_disk_usage) in the info api.
It's useful to boost up the page speed in the trade of the disk usage indicator.