### PR TITLE
Social embeds with oEmbed and Open Graph

### DIFF
--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -169,6 +169,9 @@ privileges:
     'uploads:create':               regular
     'uploads:use_downloader':       power
 
+homepage_url: https://www.example.com/
+site_url: https://www.example.com/booru
+
 ## ONLY SET THESE IF DEPLOYING OUTSIDE OF DOCKER
 #debug: 0 # generate server logs?
 #show_sql: 0 # show sql in server logs?

--- a/server/szurubooru/api/__init__.py
+++ b/server/szurubooru/api/__init__.py
@@ -1,5 +1,6 @@
 import szurubooru.api.comment_api
 import szurubooru.api.info_api
+import szurubooru.api.oembed_api
 import szurubooru.api.password_reset_api
 import szurubooru.api.pool_api
 import szurubooru.api.pool_category_api

--- a/server/szurubooru/api/__init__.py
+++ b/server/szurubooru/api/__init__.py
@@ -1,6 +1,6 @@
 import szurubooru.api.comment_api
+import szurubooru.api.embed_api
 import szurubooru.api.info_api
-import szurubooru.api.oembed_api
 import szurubooru.api.password_reset_api
 import szurubooru.api.pool_api
 import szurubooru.api.pool_category_api

--- a/server/szurubooru/api/embed_api.py
+++ b/server/szurubooru/api/embed_api.py
@@ -81,7 +81,7 @@ def post_index(ctx: rest.Context, params: Dict[str, str]) -> rest.Response:
     try:
         oembed = get_post(ctx, {}, path)
     except posts.PostNotFoundError:
-        return {"return_type": "custom", "content": index_html}
+        return {"return_type": "custom", "status_code": "404", "content": index_html}
 
     url = config.config["site_url"] + path
     new_html = index_html.replace("</head>", f'''

--- a/server/szurubooru/api/embed_api.py
+++ b/server/szurubooru/api/embed_api.py
@@ -78,7 +78,11 @@ def get_post(
 @rest.routes.get("/index(?P<path>/.+)")
 def post_index(ctx: rest.Context, params: Dict[str, str]) -> rest.Response:
     path = _index_path(params)
-    oembed = get_post(ctx, {}, path)
+    try:
+        oembed = get_post(ctx, {}, path)
+    except posts.PostNotFoundError:
+        return {"return_type": "custom", "content": index_html}
+
     url = config.config["site_url"] + path
     new_html = index_html.replace("</head>", f'''
 <meta property="og:site_name" content="{config.config["name"]}">

--- a/server/szurubooru/api/oembed_api.py
+++ b/server/szurubooru/api/oembed_api.py
@@ -1,0 +1,97 @@
+import re
+import html
+from urllib.parse import quote
+from typing import Dict, Optional
+
+from szurubooru import config, model, rest
+from szurubooru.func import (
+    auth,
+    posts,
+    serialization,
+)
+
+with open(f"{config.config['data_dir']}/../index.htm") as index:
+    index_html = index.read()
+
+def _index_path(params: Dict[str, str]) -> int:
+    try:
+        return params["path"]
+    except (TypeError, ValueError):
+        raise posts.InvalidPostIdError(
+            "Invalid post ID."
+        )
+
+
+def _get_post(post_id: int) -> model.Post:
+    return posts.get_post_by_id(post_id)
+
+
+def _get_post_id(match: re.Match) -> int:
+    post_id = match.group("post_id")
+    try:
+        return int(post_id)
+    except (TypeError, ValueError):
+        raise posts.InvalidPostIdError(
+            "Invalid post ID: %r." % post_id
+        )
+
+
+def _serialize_post(
+    ctx: rest.Context, post: Optional[model.Post]
+) -> rest.Response:
+    return posts.serialize_post(
+        post, ctx.user, options=serialization.get_serialization_options(ctx)
+    )
+
+
+@rest.routes.get("/oembed/?")
+def get_post(
+    ctx: rest.Context, _params: Dict[str, str] = {}, url: str = ""
+) -> rest.Response:
+    auth.verify_privilege(ctx.user, "posts:view")
+
+    url = url or ctx.get_param_as_string("url")
+    match = re.match(r".*?/post/(?P<post_id>\d+)", url)
+    if not match:
+        raise posts.InvalidPostIdError("Invalid post ID.")
+
+    post_id = _get_post_id(match)
+    post = _get_post(post_id)
+    serialized = _serialize_post(ctx, post)
+    embed = {
+        "version": "1.0",
+        "type": "photo",
+        "title": f"{config.config['name']} – Post #{post_id}",
+        "author_name": serialized["user"]["name"] if serialized["user"] else None,
+        "provider_name": config.config["name"],
+        "provider_url": config.config["homepage_url"],
+        "thumbnail_url": f"{config.config['site_url']}/{serialized['thumbnailUrl']}",
+        "thumbnail_width": int(config.config["thumbnails"]["post_width"]),
+        "thumbnail_height": int(config.config["thumbnails"]["post_height"]),
+        "url": f"{config.config['site_url']}/{serialized['thumbnailUrl']}",
+        "width": int(config.config["thumbnails"]["post_width"]),
+        "height": int(config.config["thumbnails"]["post_height"])
+    }
+    return embed
+
+
+@rest.routes.get("/index(?P<path>/.+)")
+def post_index(ctx: rest.Context, params: Dict[str, str]) -> rest.Response:
+    path = _index_path(params)
+    oembed = get_post(ctx, {}, path)
+    url = config.config["site_url"] + path
+    new_html = index_html.replace("</head>", f'''
+<meta property="og:site_name" content="{config.config["name"]}">
+<meta property="og:url" content="{html.escape(url)}">
+<meta property="og:type" content="article">
+<meta property="og:title" content="{html.escape(oembed['title'])}">
+<meta name="twitter:title" content="{html.escape(oembed['title'])}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="{html.escape(oembed['url'])}">
+<meta property="og:image:url" content="{html.escape(oembed['url'])}">
+<meta property="og:image:width" content="{oembed['width']}">
+<meta property="og:image:height" content="{oembed['height']}">
+<meta property="article:author" content="{html.escape(oembed['author_name'] or '')}">
+<link rel="alternate" type="application/json+oembed" href="{config.config["site_url"]}/api/oembed?url={quote(html.escape(url))}" title="{html.escape(config.config["name"])}"></head>
+''').replace("<html>", '<html prefix="og: http://ogp.me/ns#">').replace("<title>Loading...</title>", f"<title>{html.escape(oembed['title'])}</title>")
+    return {"return_type": "custom", "content": new_html}

--- a/server/szurubooru/rest/app.py
+++ b/server/szurubooru/rest/app.py
@@ -113,7 +113,7 @@ def application(
                 db.session.remove()
 
             if type(response) == dict and response.get("return_type") == "custom":
-                start_response("200", [("content-type", "text/html")])
+                start_response(response.get("status_code", "200"), [("content-type", "text/html")])
                 return (response.get("content", "").encode("utf-8"),)
 
             start_response("200", [("content-type", "application/json")])


### PR DESCRIPTION
Differences with the approaches in #421, #422 and #441:
- No new dependencies (such as an extra server, Lua scripting module, Caddy)
- Proper Twitter meta tags (`name` attribute instead of `property`)
- Only serves dynamic HTML on pages we support embeds for (currently only posts but easily extensible)
- Returns 404 status code on deleted posts
- Very minimal implementation, easy to review
- Booru works just like it currently does for those who don't make the routing changes
- Implements both oEmbed and Open Graph for the very best compatibility 

Things that can be improved later:
- Embedding of videos (currently shows a thumbnail)
- Caching (I personally don't think it's necessary, better to return up-to-date data and let the instance owner decide)
- Generic embed for static pages

Meant to be used with an nginx config like:
```
location ~ ^/booru/(post/[0-9]+)$ {
    set $query $1;
    proxy_pass http://127.0.0.1:6666/index/$query;
    proxy_set_header Accept "*/*";
}
```

Discord
![image](https://github.com/rr-/szurubooru/assets/42466980/29ce3c6f-9753-4bce-9457-72cd1e31b1c7)
Twitter
![image](https://github.com/rr-/szurubooru/assets/42466980/3abb43f3-0261-47ee-a04a-f6e2132b96cc)

Closes #416
