### PR TITLE
Flash support in modern browsers

### DIFF
--- a/client/css/post-main-view.styl
+++ b/client/css/post-main-view.styl
@@ -44,6 +44,8 @@
 
         .post-content
             margin: 0
+            background-size: cover
+            background-repeat: no-repeat
 
 .darktheme .post-view
     >.sidebar

--- a/client/html/index.htm
+++ b/client/html/index.htm
@@ -28,5 +28,6 @@
     <div id='content-holder'></div>
     <script type='text/javascript' src='js/vendor.min.js'></script>
     <script type='text/javascript' src='js/app.min.js'></script>
+    <script type='text/javascript' src='https://unpkg.com/@ruffle-rs/ruffle' async></script>
 </body>
 </html>

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -8,6 +8,7 @@
         <object class='resize-listener' width='<%- ctx.post.canvasWidth %>' height='<%- ctx.post.canvasHeight %>' data='<%- ctx.post.contentUrl %>'>
             <param name='wmode' value='transparent'/>
             <param name='movie' value='<%- ctx.post.contentUrl %>'/>
+            <div class='messages'><div class='message-wrapper'><div class='message error'>Your browser does not support Flash.</div></div></div>
         </object>
 
     <% } else if (ctx.post.type === 'video') { %>

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -1,4 +1,4 @@
-<div class='post-content post-type-<%- ctx.post.type %>'>
+<div class='post-content post-type-<%- ctx.post.type %>'<% if (ctx.post.type === 'flash') { %> style='background-image: url(<%- ctx.post.thumbnailUrl %>)'<% } %>>
     <% if (['image', 'animation'].includes(ctx.post.type)) { %>
 
         <img class='resize-listener' alt='' src='<%- ctx.post.contentUrl %>'/>
@@ -6,7 +6,7 @@
     <% } else if (ctx.post.type === 'flash') { %>
 
         <object class='resize-listener' width='<%- ctx.post.canvasWidth %>' height='<%- ctx.post.canvasHeight %>' data='<%- ctx.post.contentUrl %>'>
-            <param name='wmode' value='opaque'/>
+            <param name='wmode' value='transparent'/>
             <param name='movie' value='<%- ctx.post.contentUrl %>'/>
         </object>
 

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -1,4 +1,4 @@
-<div class='post-content post-type-<%- ctx.post.type %>'<% if (ctx.post.type === 'flash') { %> style='background-image: url(<%- ctx.post.thumbnailUrl %>)'<% } %>>
+<div class='post-content post-type-<%- ctx.post.type %>' style='<%- ctx.post.type === 'flash' ? 'background-image: url('+ctx.post.thumbnailUrl+')' : '' %>'>
     <% if (['image', 'animation'].includes(ctx.post.type)) { %>
 
         <img class='resize-listener' alt='' src='<%- ctx.post.contentUrl %>'/>

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -49,6 +49,7 @@ window.RufflePlayer.config = {
     "polyfills": true,
     "autoplay": "off",
     "warnOnUnsupportedContent": false,
+    "showSwfDownload": true,
     "splashScreen": false,
 };
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -48,7 +48,6 @@ window.RufflePlayer = window.RufflePlayer || {};
 window.RufflePlayer.config = {
     "polyfills": true,
     "autoplay": "off",
-    "backgroundColor": rgb2hex(window.getComputedStyle(document.body).backgroundColor),
     "warnOnUnsupportedContent": false,
     "splashScreen": false,
 };
@@ -112,8 +111,6 @@ Promise.resolve()
         }
 
         window.RufflePlayer.config.autoplay = settings.get().autoplayVideos ? "auto" : "off"
-        const topNav = document.getElementById("top-navigation")
-        if (topNav) window.RufflePlayer.config.backgroundColor = rgb2hex(window.getComputedStyle(topNav).backgroundColor)
     })
     .then(() => api.loginFromCookies())
     .then(

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -42,6 +42,17 @@ const pools = require("./pools.js");
 const api = require("./api.js");
 const settings = require("./models/settings.js");
 
+const rgb2hex = (rgb) => `#${rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/).slice(1).map(n => parseInt(n, 10).toString(16).padStart(2, '0')).join('')}`
+
+window.RufflePlayer = window.RufflePlayer || {};
+window.RufflePlayer.config = {
+    "polyfills": true,
+    "autoplay": "off",
+    "backgroundColor": rgb2hex(window.getComputedStyle(document.body).backgroundColor),
+    "warnOnUnsupportedContent": false,
+    "splashScreen": false,
+};
+
 Promise.resolve()
     .then(() => api.fetchConfig())
     .then(
@@ -99,6 +110,10 @@ Promise.resolve()
         if (settings.get().darkTheme) {
             document.body.classList.add("darktheme");
         }
+
+        window.RufflePlayer.config.autoplay = settings.get().autoplayVideos ? "auto" : "off"
+        const topNav = document.getElementById("top-navigation")
+        if (topNav) window.RufflePlayer.config.backgroundColor = rgb2hex(window.getComputedStyle(topNav).backgroundColor)
     })
     .then(() => api.loginFromCookies())
     .then(

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -42,8 +42,6 @@ const pools = require("./pools.js");
 const api = require("./api.js");
 const settings = require("./models/settings.js");
 
-const rgb2hex = (rgb) => `#${rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/).slice(1).map(n => parseInt(n, 10).toString(16).padStart(2, '0')).join('')}`
-
 window.RufflePlayer = window.RufflePlayer || {};
 window.RufflePlayer.config = {
     "polyfills": true,

--- a/client/js/views/settings_view.js
+++ b/client/js/views/settings_view.js
@@ -30,6 +30,7 @@ class SettingsView extends events.EventTarget {
 
     _evtSubmit(e) {
         e.preventDefault();
+        window.RufflePlayer.config.autoplay = this._find("autoplay-videos").checked ? "auto" : "off"
         this.dispatchEvent(
             new CustomEvent("submit", {
                 detail: {

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -33,6 +33,18 @@ RUN apk --no-cache add \
         "pillow-avif-plugin>=1.1.0" \
  && apk --no-cache del py3-pip
 
+# build and install ruffle exporter
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+RUN apk --no-cache add git rustup openjdk11 mesa-gl mesa-egl mesa-gles mesa-dri-gallium \
+ && rustup-init --default-toolchain nightly -y \
+ && git clone https://github.com/ruffle-rs/ruffle \
+ && cd ruffle \
+ && /root/.cargo/bin/cargo build --release --package=exporter \
+ && cp target/release/exporter /usr/bin/ \
+ && cd .. \
+ && rm -rf ruffle /root/.cargo \
+ && apk --no-cache del git rustup
+
 COPY ./ /opt/app/
 RUN rm -rf /opt/app/szurubooru/tests
 

--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -27,10 +27,9 @@ def convert_heif_to_png(content: bytes) -> bytes:
 class Image:
     def __init__(self, content: bytes) -> None:
         self.content = content
-        self._reload_info()
-        if self.info["format"]["format_name"] == "swf":
+        if mime.is_flash(mime.get_mime_type(self.content)):
             self.content = self.swf_to_png()
-            self._reload_info()
+        self._reload_info()
 
     @property
     def width(self) -> int:

--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -28,6 +28,9 @@ class Image:
     def __init__(self, content: bytes) -> None:
         self.content = content
         self._reload_info()
+        if self.info["format"]["format_name"] == "swf":
+            self.content = self.swf_to_png()
+            self._reload_info()
 
     @property
     def width(self) -> int:
@@ -60,10 +63,7 @@ class Image:
             "png",
             "-",
         ]
-        if (
-            "duration" in self.info["format"]
-            and self.info["format"]["format_name"] != "swf"
-        ):
+        if "duration" in self.info["format"]:
             duration = float(self.info["format"]["duration"])
             if duration > 3:
                 cli = [
@@ -75,6 +75,19 @@ class Image:
             raise errors.ProcessingError("Error while resizing image.")
         self.content = content
         self._reload_info()
+
+    def swf_to_png(self) -> bytes:
+        return self._execute(
+            [
+                "--silent",
+                "-g",
+                "gl",
+                "--",
+                "{path}",
+                "-",
+            ],
+            program="exporter",
+        )
 
     def to_png(self) -> bytes:
         return self._execute(
@@ -315,7 +328,7 @@ class Image:
         )
         assert "format" in self.info
         assert "streams" in self.info
-        if len(self.info["streams"]) < 1:
+        if len(self.info["streams"]) < 1 and self.info["format"]["format_name"] != "swf":
             logger.warning("The video contains no video streams.")
             raise errors.ProcessingError(
                 "The video contains no video streams."

--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -287,7 +287,10 @@ class Image:
         with util.create_temp_file(suffix="." + extension) as handle:
             handle.write(self.content)
             handle.flush()
-            cli = [program, "-loglevel", "32" if get_logs else "24"] + cli
+            if program in ["ffmpeg", "ffprobe"]:
+                cli = [program, "-loglevel", "32" if get_logs else "24"] + cli
+            else:
+                cli = [program] + cli
             cli = [part.format(path=handle.name) for part in cli]
             proc = subprocess.Popen(
                 cli,
@@ -298,7 +301,7 @@ class Image:
             out, err = proc.communicate()
             if proc.returncode != 0:
                 logger.warning(
-                    "Failed to execute ffmpeg command (cli=%r, err=%r)",
+                    "Failed to execute {program} command (cli=%r, err=%r)".format(program=program),
                     " ".join(shlex.quote(arg) for arg in cli),
                     err,
                 )

--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -330,7 +330,7 @@ class Image:
         )
         assert "format" in self.info
         assert "streams" in self.info
-        if len(self.info["streams"]) < 1 and self.info["format"]["format_name"] != "swf":
+        if len(self.info["streams"]) < 1:
             logger.warning("The video contains no video streams.")
             raise errors.ProcessingError(
                 "The video contains no video streams."


### PR DESCRIPTION
Makes the booru able to generate thumbnails for any SWF supported by Ruffle, and adds a polyfill for modern browsers.

For non-docker setups, build [ruffle](https://github.com/ruffle-rs/ruffle)'s exporter binary with `cargo build --release --package=exporter`.

This also fixes uploading of all SWF files submitted in #427.
Closes #541.