### PR TITLE
Thumbnail rework

### DIFF
--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -106,6 +106,11 @@ form .fa-question-circle-o
                     background-color: $scrollbar-bg-color
                 &::-webkit-scrollbar-thumb
                     background-color: $scrollbar-thumb-color
+                li[data-name=view]
+                    background: $button-enabled-background-color
+                    margin-right: 1em
+                    a
+                        color: $button-enabled-text-color
     >.content-wrapper:not(.transparent)
         background: $top-navigation-color
         padding: 1.8em
@@ -214,8 +219,6 @@ nav
         ul li[data-name=settings],
         ul li[data-name=help]
             float: none
-        .access-key
-            text-decoration: underline
         .thumbnail
             width: 1.5em
             height: 1.5em
@@ -243,9 +246,6 @@ nav
         ul
             #mobile-navigation-toggle
                 color: $text-color-darktheme
-
-a .access-key
-    text-decoration: underline
 
 .messages
     margin: 0 auto
@@ -284,27 +284,23 @@ a .access-key
     /*background-image: attr(data-src url)*/ /* not available yet */
     vertical-align: middle
     background-repeat: no-repeat
-    background-size: cover
+    background-size: contain
     background-position: center
     display: inline-block
     width: 20px
     height: 20px
     &.empty
         background-image:
-            linear-gradient(45deg, $transparency-grid-square-color 25%, transparent 25%),
-            linear-gradient(-45deg, $transparency-grid-square-color 25%, transparent 25%),
-            linear-gradient(45deg, transparent 75%, $transparency-grid-square-color 75%),
-            linear-gradient(-45deg, transparent 75%, $transparency-grid-square-color 75%)
-        background-position: 0 0, 0 10px, 10px -10px, -10px 0px
-        background-repeat: repeat
-        background-size: 20px 20px
-    img
+            repeating-linear-gradient(45deg, $window-color, $window-color 10px, #e6e6e6 10px, #e6e6e6 20px)
+    img, video
         opacity: 0
-        width: auto
+        object-fit: cover
+        width: 100%
         height: 100%
-    video
-        width: auto
-        height: 100%
+
+.darktheme .thumbnail.empty
+    background-image:
+        repeating-linear-gradient(45deg, $window-color-darktheme, $window-color-darktheme 10px, #333 10px, #333 20px)
 
 .flexbox-dummy
     height: 0 !important

--- a/client/css/core-general.styl
+++ b/client/css/core-general.styl
@@ -287,6 +287,7 @@ nav
     background-size: contain
     background-position: center
     display: inline-block
+    overflow: hidden
     width: 20px
     height: 20px
     &.empty

--- a/client/css/post-content-control.styl
+++ b/client/css/post-content-control.styl
@@ -1,14 +1,16 @@
 @import colors
 
 .post-container
-    .post-content.transparency-grid img
-        background-image:
-            linear-gradient(45deg, $transparency-grid-square-color 25%, transparent 25%),
-            linear-gradient(-45deg, $transparency-grid-square-color 25%, transparent 25%),
-            linear-gradient(45deg, transparent 75%, $transparency-grid-square-color 75%),
-            linear-gradient(-45deg, transparent 75%, $transparency-grid-square-color 75%)
-        background-size: 20px 20px
-        background-position: 0 0, 0 10px, 10px -10px, -10px 0px
+    .post-content
+        &.transparency-grid, &.post-error
+            background-image:
+                linear-gradient(45deg, $transparency-grid-square-color 25%, transparent 25%),
+                linear-gradient(-45deg, $transparency-grid-square-color 25%, transparent 25%),
+                linear-gradient(45deg, transparent 75%, $transparency-grid-square-color 75%),
+                linear-gradient(-45deg, transparent 75%, $transparency-grid-square-color 75%)
+            background-position: 0 0, 0 10px, 10px -10px, -10px 0px
+            background-repeat: repeat
+            background-size: 20px 20px
 
     text-align: center
     .post-content
@@ -17,6 +19,8 @@
         position: relative
 
         .resize-listener
+            background-repeat: no-repeat
+            background-size: cover
             position: absolute
             left: 0
             right: 0
@@ -27,3 +31,14 @@
 
         img
             image-orientation: from-image
+
+.darktheme .post-container .post-content
+    &.transparency-grid, &.post-error
+        background-image:
+            linear-gradient(45deg, $transparency-grid-square-color 25%, transparent 25%),
+            linear-gradient(-45deg, $transparency-grid-square-color 25%, transparent 25%),
+            linear-gradient(45deg, transparent 75%, $transparency-grid-square-color 75%),
+            linear-gradient(-45deg, transparent 75%, $transparency-grid-square-color 75%)
+        background-position: 0 0, 0 10px, 10px -10px, -10px 0px
+        background-repeat: repeat
+        background-size: 20px 20px

--- a/client/css/post-upload.styl
+++ b/client/css/post-upload.styl
@@ -71,9 +71,9 @@ $cancel-button-color = tomato
                     display: block
                     height: 100%
                     width: 100%
-                    .thumbnail
-                        width: 100%
-                        height: 100%
+                .thumbnail
+                    width: 100%
+                    height: 100%
 
             .uploadable
                 border: 1px solid $upload-border-color

--- a/client/css/post-upload.styl
+++ b/client/css/post-upload.styl
@@ -74,6 +74,10 @@ $cancel-button-color = tomato
                 .thumbnail
                     width: 100%
                     height: 100%
+                    video
+                        opacity: 1
+                    img, video
+                        object-fit: contain
 
             .uploadable
                 border: 1px solid $upload-border-color

--- a/client/css/post-upload.styl
+++ b/client/css/post-upload.styl
@@ -62,22 +62,18 @@ $cancel-button-color = tomato
             margin: 0 0 1.2em 0
             padding-left: 13em
 
-            img
-                width: 100%
-                height: 100%
-            
-            video
-                width: 100%
-                height: 100%
-
             &>.thumbnail-wrapper
                 float: left
                 width: 12em
                 height: 8em
                 margin: 0 0 0 -13em
-                .thumbnail
-                    width: 100%
+                a
+                    display: block
                     height: 100%
+                    width: 100%
+                    .thumbnail
+                        width: 100%
+                        height: 100%
 
             .uploadable
                 border: 1px solid $upload-border-color

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -24,7 +24,7 @@
             },
             ctx.makeElement('source', {
                 type: ctx.post.mimeType,
-                src: ctx.post.contentUrl + '#t=0.001',
+                src: ctx.post.contentUrl,
             }),
             'Your browser doesn\'t support HTML5 videos.')
         %>

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -1,13 +1,14 @@
 <div class='post-content post-type-<%- ctx.post.type %>'>
     <% if (['image', 'animation'].includes(ctx.post.type)) { %>
 
-        <img class='resize-listener' alt='' src='<%- ctx.post.contentUrl %>'/>
+        <img class='resize-listener' alt='' src='<%- ctx.post.contentUrl %>' draggable='false' fetchPriority='high'/>
 
     <% } else if (ctx.post.type === 'flash') { %>
 
         <object class='resize-listener' width='<%- ctx.post.canvasWidth %>' height='<%- ctx.post.canvasHeight %>' data='<%- ctx.post.contentUrl %>'>
-            <param name='wmode' value='opaque'/>
+            <param name='wmode' value='transparent'/>
             <param name='movie' value='<%- ctx.post.contentUrl %>'/>
+            <div class='messages'><div class='message-wrapper'><div class='message error'>Your browser does not support Flash.</div></div></div>
         </object>
 
     <% } else if (ctx.post.type === 'video') { %>

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -19,11 +19,12 @@
                 loop: (ctx.post.flags || []).includes('loop'),
                 playsinline: true,
                 autoplay: ctx.autoplay,
+                preload: 'auto',
                 poster: ctx.post.thumbnailUrl,
             },
             ctx.makeElement('source', {
                 type: ctx.post.mimeType,
-                src: ctx.post.contentUrl,
+                src: ctx.post.contentUrl + '#t=0.001',
             }),
             'Your browser doesn\'t support HTML5 videos.')
         %>

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -19,6 +19,7 @@
                 loop: (ctx.post.flags || []).includes('loop'),
                 playsinline: true,
                 autoplay: ctx.autoplay,
+                poster: ctx.post.thumbnailUrl,
             },
             ctx.makeElement('source', {
                 type: ctx.post.mimeType,

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -20,7 +20,7 @@
                 playsinline: true,
                 autoplay: ctx.autoplay,
                 preload: 'auto',
-                poster: ctx.post.thumbnailUrl,
+                poster: ctx.post.originalThumbnailUrl,
             },
             ctx.makeElement('source', {
                 type: ctx.post.mimeType,

--- a/client/html/post_upload_row.tpl
+++ b/client/html/post_upload_row.tpl
@@ -10,7 +10,7 @@
 
             <div class='thumbnail'>
                 <a href='<%= ctx.uploadable.previewUrl %>'>
-                    <video id='video' nocontrols muted>
+                    <video nocontrols muted>
                         <source type='<%- ctx.uploadable.mimeType %>' src='<%- ctx.uploadable.previewUrl %>'/>
                     </video>
                 </a>

--- a/client/js/controllers/comments_controller.js
+++ b/client/js/controllers/comments_controller.js
@@ -8,7 +8,7 @@ const PageController = require("../controllers/page_controller.js");
 const CommentsPageView = require("../views/comments_page_view.js");
 const EmptyView = require("../views/empty_view.js");
 
-const fields = ["id", "comments", "commentCount", "thumbnailUrl"];
+const fields = ["id", "comments", "commentCount", "thumbnailUrl", "customThumbnailUrl"];
 
 class CommentsController {
     constructor(ctx) {

--- a/client/js/controllers/post_list_controller.js
+++ b/client/js/controllers/post_list_controller.js
@@ -14,6 +14,7 @@ const EmptyView = require("../views/empty_view.js");
 const fields = [
     "id",
     "thumbnailUrl",
+    "customThumbnailUrl",
     "type",
     "safety",
     "score",

--- a/client/js/controls/post_content_control.js
+++ b/client/js/controls/post_content_control.js
@@ -119,20 +119,28 @@ class PostContentControl {
             post: this._post,
             autoplay: settings.get().autoplayVideos,
         });
+        function load(argument) {
+            if (settings.get().transparencyGrid) {
+                newNode.classList.add("transparency-grid");
+            }
+            newNode.firstElementChild.style.backgroundImage = "";
+        }
         if (["image", "flash"].includes(this._post.type)) {
-            newNode.style.backgroundImage = "url("+this._post.thumbnailUrl+")";
+            newNode.firstElementChild.style.backgroundImage = "url("+this._post.thumbnailUrl+")";
         }
         if (this._post.type == "image") {
-            newNode.firstElementChild.addEventListener("load", (e) => {
-                if (settings.get().transparencyGrid) {
-                    newNode.classList.add("transparency-grid");
-                } else {
-                    newNode.style.backgroundImage = "";
-                }
-            });
+            newNode.firstElementChild.addEventListener("load", load);
         } else if (settings.get().transparencyGrid) {
             newNode.classList.add("transparency-grid");
         }
+        newNode.firstElementChild.addEventListener("error", (e) => {
+            newNode.classList.add("post-error");
+            if (["image", "animation"].includes(this._post.type)) {
+                newNode.firstElementChild.removeEventListener("load", load);
+                newNode.firstElementChild.style.backgroundImage = "url("+this._post.thumbnailUrl+")";
+                newNode.firstElementChild.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+            }
+        });
         if (this._postContentNode) {
             this._hostNode.replaceChild(newNode, this._postContentNode);
         } else {

--- a/client/js/controls/post_content_control.js
+++ b/client/js/controls/post_content_control.js
@@ -126,7 +126,7 @@ class PostContentControl {
             newNode.firstElementChild.style.backgroundImage = "";
         }
         if (["image", "flash"].includes(this._post.type)) {
-            newNode.firstElementChild.style.backgroundImage = "url("+this._post.thumbnailUrl+")";
+            newNode.firstElementChild.style.backgroundImage = "url("+this._post.originalThumbnailUrl+")";
         }
         if (this._post.type == "image") {
             newNode.firstElementChild.addEventListener("load", load);
@@ -137,7 +137,7 @@ class PostContentControl {
             newNode.classList.add("post-error");
             if (["image", "animation"].includes(this._post.type)) {
                 newNode.firstElementChild.removeEventListener("load", load);
-                newNode.firstElementChild.style.backgroundImage = "url("+this._post.thumbnailUrl+")";
+                newNode.firstElementChild.style.backgroundImage = "url("+this._post.originalThumbnailUrl+")";
                 newNode.firstElementChild.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
             }
         });

--- a/client/js/controls/post_content_control.js
+++ b/client/js/controls/post_content_control.js
@@ -119,7 +119,18 @@ class PostContentControl {
             post: this._post,
             autoplay: settings.get().autoplayVideos,
         });
-        if (settings.get().transparencyGrid) {
+        if (["image", "flash"].includes(this._post.type)) {
+            newNode.style.backgroundImage = "url("+this._post.thumbnailUrl+")";
+        }
+        if (this._post.type == "image") {
+            newNode.firstElementChild.addEventListener("load", (e) => {
+                if (settings.get().transparencyGrid) {
+                    newNode.classList.add("transparency-grid");
+                } else {
+                    newNode.style.backgroundImage = "";
+                }
+            });
+        } else if (settings.get().transparencyGrid) {
             newNode.classList.add("transparency-grid");
         }
         if (this._postContentNode) {

--- a/client/js/controls/post_edit_sidebar_control.js
+++ b/client/js/controls/post_edit_sidebar_control.js
@@ -139,7 +139,7 @@ class PostEditSidebarControl extends events.EventTarget {
                 this._evtRemoveThumbnailClick(e)
             );
             this._thumbnailRemovalLinkNode.style.display = this._post
-                .hasCustomThumbnail
+                .customThumbnailUrl
                 ? "block"
                 : "none";
         }

--- a/client/js/models/post.js
+++ b/client/js/models/post.js
@@ -70,6 +70,14 @@ class Post extends events.EventTarget {
         return this._thumbnailUrl;
     }
 
+    get customThumbnailUrl() {
+        return this._customThumbnailUrl;
+    }
+
+    get originalThumbnailUrl() {
+        return this._originalThumbnailUrl;
+    }
+
     get source() {
         return this._source;
     }
@@ -144,10 +152,6 @@ class Post extends events.EventTarget {
 
     get ownScore() {
         return this._ownScore;
-    }
-
-    get hasCustomThumbnail() {
-        return this._hasCustomThumbnail;
     }
 
     set flags(value) {
@@ -477,7 +481,9 @@ class Post extends events.EventTarget {
                 response.contentUrl,
                 document.getElementsByTagName("base")[0].href
             ).href,
-            _thumbnailUrl: response.thumbnailUrl,
+            _thumbnailUrl: response.customThumbnailUrl ? response.customThumbnailUrl : response.thumbnailUrl,
+            _customThumbnailUrl: response.customThumbnailUrl,
+            _originalThumbnailUrl: response.thumbnailUrl,
             _source: response.source,
             _canvasWidth: response.canvasWidth,
             _canvasHeight: response.canvasHeight,
@@ -491,7 +497,6 @@ class Post extends events.EventTarget {
             _favoriteCount: response.favoriteCount,
             _ownScore: response.ownScore,
             _ownFavorite: response.ownFavorite,
-            _hasCustomThumbnail: response.hasCustomThumbnail,
         });
 
         for (let obj of [this, this._orig]) {

--- a/client/js/util/views.js
+++ b/client/js/util/views.js
@@ -49,7 +49,7 @@ function makeThumbnail(url) {
                   style: `background-image: url(\'${url}\')`,
               }
             : { class: "thumbnail empty" },
-        makeElement("img", { alt: "thumbnail", src: url })
+        makeElement("img", { alt: "thumbnail", src: url, draggable: "false" })
     );
 }
 

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -401,6 +401,14 @@ class PostUploadView extends events.EventTarget {
             .addEventListener("click", (e) =>
                 this._evtMoveClick(e, uploadable, 1)
             );
+        if (uploadable.type == "video") {
+            const video = rowNode.querySelector("video");
+            if (video) {
+                video.addEventListener("loadedmetadata", (e) => {
+                    if (!isNaN(video.duration)) video.currentTime = Math.floor(video.duration * 0.3)
+                });
+            }
+        }
     }
 
     _updateThumbnailNode(uploadable) {

--- a/server/szurubooru/func/files.py
+++ b/server/szurubooru/func/files.py
@@ -1,4 +1,5 @@
 import os
+import glob
 from typing import Any, List, Optional
 
 from szurubooru import config
@@ -22,6 +23,10 @@ def scan(path: str) -> List[Any]:
     if has(path):
         return list(os.scandir(_get_full_path(path)))
     return []
+
+
+def find(path: str, pattern: str) -> List[Any]:
+    return glob.glob(glob.escape(_get_full_path(path) + "/") + pattern)
 
 
 def move(source_path: str, target_path: str) -> None:

--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -41,7 +41,7 @@ class Image:
     def frames(self) -> int:
         return self.info["streams"][0]["nb_read_frames"]
 
-    def resize_fill(self, width: int, height: int) -> None:
+    def resize_fill(self, width: int, height: int, pixel_format: str = "rgb32") -> None:
         width_greater = self.width > self.height
         width, height = (-1, height) if width_greater else (width, -1)
 
@@ -51,7 +51,7 @@ class Image:
             "-f",
             "image2",
             "-filter:v",
-            "scale='{width}:{height}'".format(width=width, height=height),
+            "format={pixel_format},scale={width}:{height}:flags=bicubic".format(pixel_format=pixel_format, width=width, height=height),
             "-map",
             "0:v:0",
             "-vframes",

--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -41,7 +41,7 @@ class Image:
     def frames(self) -> int:
         return self.info["streams"][0]["nb_read_frames"]
 
-    def resize_fill(self, width: int, height: int, pixel_format: str = "rgb32") -> None:
+    def resize_fill(self, width: int, height: int, keep_transparency: bool = True) -> None:
         width_greater = self.width > self.height
         width, height = (-1, height) if width_greater else (width, -1)
 
@@ -50,8 +50,12 @@ class Image:
             "{path}",
             "-f",
             "image2",
-            "-filter:v",
-            "format={pixel_format},scale={width}:{height}:flags=bicubic".format(pixel_format=pixel_format, width=width, height=height),
+            "-filter_complex",
+            (
+                "format=rgb32,scale={width}:{height}:flags=bicubic"
+                if keep_transparency else
+                "[0:v]format=rgb32,scale={width}:{height}:flags=bicubic[a];color=white[b];[b][a]scale2ref[b][a];[b][a]overlay"
+            ).format(width=width, height=height),
             "-map",
             "0:v:0",
             "-vframes",

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -689,7 +689,7 @@ def generate_post_thumbnail(post: model.Post) -> None:
         image.resize_fill(
             int(config.config["thumbnails"]["post_width"]),
             int(config.config["thumbnails"]["post_height"]),
-            "rgb24",
+            keep_transparency=False,
         )
         files.save(get_post_thumbnail_path(post), image.to_jpeg())
     except errors.ProcessingError:

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -689,6 +689,7 @@ def generate_post_thumbnail(post: model.Post) -> None:
         image.resize_fill(
             int(config.config["thumbnails"]["post_width"]),
             int(config.config["thumbnails"]["post_height"]),
+            "rgb24",
         )
         files.save(get_post_thumbnail_path(post), image.to_jpeg())
     except errors.ProcessingError:

--- a/server/szurubooru/tests/func/test_posts.py
+++ b/server/szurubooru/tests/func/test_posts.py
@@ -72,12 +72,12 @@ def test_get_post_thumbnail_path(input_mime_type):
 
 
 @pytest.mark.parametrize("input_mime_type", ["image/jpeg", "image/gif"])
-def test_get_post_thumbnail_backup_path(input_mime_type):
+def test_get_post_custom_thumbnail_path(input_mime_type):
     post = model.Post()
     post.post_id = 1
     post.mime_type = input_mime_type
     assert (
-        posts.get_post_thumbnail_backup_path(post)
+        posts.get_post_custom_thumbnail_path(post)
         == "posts/custom-thumbnails/1_244c8840887984c4.dat"
     )
 


### PR DESCRIPTION
Higher quality and lower filesize thumbnails with `cjpeg` (provided by mozjpeg for quality or libjpeg-turbo for speed).

Videos in the upload form now have a preview that matches the final thumbnail.

Thumbnails are now used as placeholder while the full-size image is loading on post pages.  
Thumbnail stays if the full-size image load fails. If both pics fail, the transparency grid is shown (if enabled).

Videos have two thumbnails, one taken at 30% into the video (the "custom" thumbnail shown in search results), and one of the first frame (the thumbnail used as a preroll on post pages).

Images are now resized in RGB even for indexed color PNGs. It would lead to ugly dithering that also hurt compression.
Before 
![image](https://github.com/rr-/szurubooru/assets/42466980/950e07a9-70c8-4718-81b4-7f4f3b527d59)
After
![image](https://github.com/rr-/szurubooru/assets/42466980/bb378e7a-153b-4d69-9fd8-6f3fe72e472c)

Thumbnail filenames are prefixed with `sample_` to make it clear to the user they didn't download the original image.
