### PR TITLE
client: add null checks

### DIFF
--- a/client/js/controllers/pool_controller.js
+++ b/client/js/controllers/pool_controller.js
@@ -91,16 +91,16 @@ class PoolController {
     _evtUpdate(e) {
         this._view.clearMessages();
         this._view.disableForm();
-        if (e.detail.names !== undefined) {
+        if (e.detail.names !== undefined && e.detail.names !== null) {
             e.detail.pool.names = e.detail.names;
         }
-        if (e.detail.category !== undefined) {
+        if (e.detail.category !== undefined && e.detail.category !== null) {
             e.detail.pool.category = e.detail.category;
         }
-        if (e.detail.description !== undefined) {
+        if (e.detail.description !== undefined && e.detail.description !== null) {
             e.detail.pool.description = e.detail.description;
         }
-        if (e.detail.posts !== undefined) {
+        if (e.detail.posts !== undefined && e.detail.posts !== null) {
             e.detail.pool.posts.clear();
             for (let postId of e.detail.posts) {
                 e.detail.pool.posts.add(

--- a/client/js/controllers/post_main_controller.js
+++ b/client/js/controllers/post_main_controller.js
@@ -169,22 +169,22 @@ class PostMainController extends BasePostController {
         this._view.sidebarControl.disableForm();
         this._view.sidebarControl.clearMessages();
         const post = e.detail.post;
-        if (e.detail.safety !== undefined) {
+        if (e.detail.safety !== undefined && e.detail.safety !== null) {
             post.safety = e.detail.safety;
         }
-        if (e.detail.flags !== undefined) {
+        if (e.detail.flags !== undefined && e.detail.flags !== null) {
             post.flags = e.detail.flags;
         }
-        if (e.detail.relations !== undefined) {
+        if (e.detail.relations !== undefined && e.detail.relations !== null) {
             post.relations = e.detail.relations;
         }
-        if (e.detail.content !== undefined) {
+        if (e.detail.content !== undefined && e.detail.content !== null) {
             post.newContent = e.detail.content;
         }
-        if (e.detail.thumbnail !== undefined) {
+        if (e.detail.thumbnail !== undefined && e.detail.thumbnail !== null) {
             post.newThumbnail = e.detail.thumbnail;
         }
-        if (e.detail.source !== undefined) {
+        if (e.detail.source !== undefined && e.detail.source !== null) {
             post.source = e.detail.source;
         }
         post.save().then(

--- a/client/js/controllers/tag_controller.js
+++ b/client/js/controllers/tag_controller.js
@@ -95,13 +95,13 @@ class TagController {
     _evtUpdate(e) {
         this._view.clearMessages();
         this._view.disableForm();
-        if (e.detail.names !== undefined) {
+        if (e.detail.names !== undefined && e.detail.names !== null) {
             e.detail.tag.names = e.detail.names;
         }
-        if (e.detail.category !== undefined) {
+        if (e.detail.category !== undefined && e.detail.category !== null) {
             e.detail.tag.category = e.detail.category;
         }
-        if (e.detail.description !== undefined) {
+        if (e.detail.description !== undefined && e.detail.description !== null) {
             e.detail.tag.description = e.detail.description;
         }
         e.detail.tag.save().then(

--- a/client/js/controllers/user_controller.js
+++ b/client/js/controllers/user_controller.js
@@ -175,21 +175,21 @@ class UserController {
         const isLoggedIn = api.isLoggedIn(e.detail.user);
         const infix = isLoggedIn ? "self" : "any";
 
-        if (e.detail.name !== undefined) {
+        if (e.detail.name !== undefined && e.detail.name !== null) {
             e.detail.user.name = e.detail.name;
         }
-        if (e.detail.email !== undefined) {
+        if (e.detail.email !== undefined && e.detail.email !== null) {
             e.detail.user.email = e.detail.email;
         }
-        if (e.detail.rank !== undefined) {
+        if (e.detail.rank !== undefined && e.detail.rank !== null) {
             e.detail.user.rank = e.detail.rank;
         }
 
-        if (e.detail.password !== undefined) {
+        if (e.detail.password !== undefined && e.detail.password !== null) {
             e.detail.user.password = e.detail.password;
         }
 
-        if (e.detail.avatarStyle !== undefined) {
+        if (e.detail.avatarStyle !== undefined && e.detail.avatarStyle !== null) {
             e.detail.user.avatarStyle = e.detail.avatarStyle;
             if (e.detail.avatarContent) {
                 e.detail.user.avatarContent = e.detail.avatarContent;
@@ -302,7 +302,7 @@ class UserController {
         this._view.clearMessages();
         this._view.disableForm();
 
-        if (e.detail.note !== undefined) {
+        if (e.detail.note !== undefined && e.detail.note !== null) {
             e.detail.userToken.note = e.detail.note;
         }
 

--- a/client/js/controls/post_edit_sidebar_control.js
+++ b/client/js/controls/post_edit_sidebar_control.js
@@ -427,7 +427,7 @@ class PostEditSidebarControl extends events.EventTarget {
                         : undefined,
 
                     thumbnail:
-                        this._newPostThumbnail !== undefined
+                        this._newPostThumbnail !== undefined && this._newPostThumbnail !== null
                             ? this._newPostThumbnail
                             : undefined,
 

--- a/client/js/models/post.js
+++ b/client/js/models/post.js
@@ -271,7 +271,7 @@ class Post extends events.EventTarget {
         if (this._newContent) {
             files.content = this._newContent;
         }
-        if (this._newThumbnail !== undefined) {
+        if (this._newThumbnail !== undefined && this._newThumbnail !== null) {
             files.thumbnail = this._newThumbnail;
         }
         if (this._source !== this._orig._source) {


### PR DESCRIPTION
This fixes some crashes.

`_newPostThumbnail`/`_newThumbnail` is a special case where we should allow null for clearing on-server custom thumbnails, but it was previously crashing anyway because of a deeper rooted issue.  
That's addressed in #646. In this PR the initial state just does nothing instead of crashing.