### PR TITLE
Fix moving notes by arrow keys

### DIFF
--- a/client/js/controls/post_notes_overlay_control.js
+++ b/client/js/controls/post_notes_overlay_control.js
@@ -193,7 +193,7 @@ class SelectedState extends ActiveState {
             [KEY_DOWN]: [0, delta],
             [KEY_RIGHT]: [delta, 0],
         };
-        if (Object.prototype.hasOwnProperty.call(offsetMap, e.witch)) {
+        if (Object.prototype.hasOwnProperty.call(offsetMap, e.which)) {
             e.stopPropagation();
             e.stopImmediatePropagation();
             e.preventDefault();


### PR DESCRIPTION
A typo in `client/js/controls/post_notes_overlay_control.js` prevents the functionality from working.