### PR TITLE
Make notes scale from the center when using the mouse

### DIFF
--- a/client/js/controls/post_notes_overlay_control.js
+++ b/client/js/controls/post_notes_overlay_control.js
@@ -399,6 +399,11 @@ class ScalingNoteState extends ActiveState {
         }));
         this._originalMousePoint = mousePoint;
         this._originalSize = _getNoteSize(note);
+        this._origin = _getNoteCentroid(this._note);
+        this._scaleDirection = new Point(
+            mousePoint.x > this._origin.x ? 1 : -1,
+            mousePoint.y > this._origin.y ? 1 : -1
+        );
     }
 
     evtCanvasKeyDown(e) {
@@ -417,22 +422,22 @@ class ScalingNoteState extends ActiveState {
     evtCanvasMouseMove(e) {
         const mousePoint = this._getPointFromEvent(e);
         const originalMousePoint = this._originalMousePoint;
+        const origin = this._origin;
         const originalSize = this._originalSize;
+        const scaleDirection = this._scaleDirection;
+        const scale = new Point(
+            1 +
+                ((mousePoint.x - originalMousePoint.x) / originalSize.x) *
+                    scaleDirection.x,
+            1 +
+                ((mousePoint.y - originalMousePoint.y) / originalSize.y) *
+                    scaleDirection.y
+        );
         for (let i of misc.range(this._note.polygon.length)) {
-            const polygonPoint = this._note.polygon.at(i);
-            const originalPolygonPoint = this._originalPolygon[i];
-            polygonPoint.x =
-                originalMousePoint.x +
-                (originalPolygonPoint.x - originalMousePoint.x) *
-                    (1 +
-                        (mousePoint.x - originalMousePoint.x) /
-                            originalSize.x);
-            polygonPoint.y =
-                originalMousePoint.y +
-                (originalPolygonPoint.y - originalMousePoint.y) *
-                    (1 +
-                        (mousePoint.y - originalMousePoint.y) /
-                            originalSize.y);
+            const point = this._note.polygon.at(i);
+            const originalPoint = this._originalPolygon[i];
+            point.x = origin.x + (originalPoint.x - origin.x) * scale.x;
+            point.y = origin.y + (originalPoint.y - origin.y) * scale.y;
         }
     }
 


### PR DESCRIPTION
When holding down shift and dragging the mouse, you can scale a note. Previously it scaled about the original mouse location, which resulted in unintuitive scaling behaviour where the note moves while being scaled. This change brings it in line with scaling via the keyboard (shift+arrow keys).

Old:

https://github.com/rr-/szurubooru/assets/13610073/25106906-42cb-487f-955d-4bd1762cf887

New:

https://github.com/rr-/szurubooru/assets/13610073/28bd06ac-cee6-4574-8c9d-fd6d211d6faa
