### PR TITLE
client/css: fix comment word-break

### DIFF
--- a/client/css/comment-control.styl
+++ b/client/css/comment-control.styl
@@ -129,7 +129,7 @@ $comment-border-color = #DDD
 .comment-content
     p
         word-wrap: normal
-        word-break: break-all
+        word-break: break-word
 
     ul, ol
         list-style-position: inside


### PR DESCRIPTION
`break-all` makes it hard to read actual comments, e.g.

![Screenshot 2024-06-07 125754](https://github.com/rr-/szurubooru/assets/110625/64b0730c-74e4-47d0-9608-77855861bd87)

vs

![Screenshot 2024-06-07 125814](https://github.com/rr-/szurubooru/assets/110625/34cb3f44-633f-41a8-89d7-5e3ee4517acd)
