### PR TITLE
If attempting to reverse-search using a PSD, convert to PNG first

### DIFF
--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -928,6 +928,12 @@ def search_by_image_exact(image_content: bytes) -> Optional[model.Post]:
 
 
 def search_by_image(image_content: bytes) -> List[Tuple[float, model.Post]]:
+    # Convert PSD files to PNG so pillow can open them
+    if image_content[0:4] == b"\x38\x42\x50\x53":
+        image = images.Image(image_content)
+        image.resize_fill(image.width, image.height)
+        image_content = image.content
+
     query_signature = image_hash.generate_signature(image_content)
     query_words = image_hash.generate_words(query_signature)
 


### PR DESCRIPTION
Currently, if attempting to reverse-search and uploading a PSD, the backend will take a long time (sometimes over a minute) trying to open the PSD before failing and using only exact file matches. 

This is fine, as long as the time is less than 1 minute, but if it's longer than that, the API times out.

Turns out converting to a PNG is much faster than trying to open a PSD, so this fixes that and gives some rough image check