### PR TITLE
server/requirements.txt: update heif-image-plugin to reflect Dockerfile

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,7 @@
 alembic>=0.8.5
 certifi>=2017.11.5
 coloredlogs==5.0
-heif-image-plugin==0.3.2
+heif-image-plugin>=0.3.2
 numpy>=1.8.2
 pillow-avif-plugin~=1.1.0
 pillow>=4.3.0


### PR DESCRIPTION
Installing this without Docker was failing due to an out of date heif-image-plugin. This commit fixes that.