### PR TITLE
Support reading env vars on Podman

### DIFF
--- a/server/szurubooru/config.py
+++ b/server/szurubooru/config.py
@@ -57,7 +57,7 @@ def _read_config() -> Dict:
         logger.warning(
             "'config.yaml' should be a file, not a directory, skipping"
         )
-    if os.path.exists("/.dockerenv"):
+    if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
         ret = _merge(ret, _docker_config())
     return ret
 


### PR DESCRIPTION
When a container is started on Podman, it creates a file at `/run/.containerenv` instead of `/.dockerenv`. Everything else otherwise runs identically. Detecting this file thereby gives it support for Podman and properly load the environment variables.