### PR TITLE
Fixed the tag suggestions being shown as [object Object] when added m…

### DIFF
--- a/client/js/controls/auto_complete_control.js
+++ b/client/js/controls/auto_complete_control.js
@@ -255,7 +255,7 @@ class AutoCompleteControl {
             const link = document.createElement("a");
             link.innerHTML = resultItem.caption;
             link.setAttribute("href", "");
-            link.setAttribute("data-key", resultItem.value);
+            link.setAttribute("data-key", resultItem.value._origName);
             link.addEventListener("mouseenter", (e) => {
                 e.preventDefault();
                 this._activeResult = resultIndexWorkaround;

--- a/client/js/controls/tag_input_control.js
+++ b/client/js/controls/tag_input_control.js
@@ -386,7 +386,7 @@ class TagInputControl extends events.EventTarget {
                     );
                 }
                 for (let suggestion of tag.suggestions || []) {
-                    this._suggestions.set(suggestion, 5);
+                    this._suggestions.set(suggestion._origName, 5);
                 }
                 if (this._suggestions.length) {
                     this._openSuggestionsPopup();


### PR DESCRIPTION
Hello,
when manually adding a tag suggestion to a tag under the tags edit page you cannot actually see it when you want to use it. If you click on the tag while editing a post, you simply see `[object Object]`, which isn't helpful of course.

It can be simply fixed by accessing `suggestion._origName`. I tested it and it works without any problems. Even when adding multiple suggestions to an tag it doesn't cause any issues.