### PR TITLE
client+server/docker: add .psd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ server/**/lib/
 server/**/bin/
 server/**/pyvenv.cfg
 __pycache__/
+
+# Developer Tools
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ scrubbing](https://sjp.pwn.pl/sjp/;2527372). It is pronounced as *shoorubooru*.
 
 ## Features
 
-- Post content: images (JPG, PNG, GIF, animated GIF), videos (MP4, WEBM), Flash animations
+- Post content: images (JPG, PNG, GIF, animated GIF), videos (MP4, WEBM), Flash animations, project files (PSD)
 - Ability to retrieve web video content using [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 - Post comments
 - Post notes / annotations, including arbitrary polygons

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -1,7 +1,11 @@
 <div class='post-content post-type-<%- ctx.post.type %>'>
     <% if (['image', 'animation'].includes(ctx.post.type)) { %>
 
-        <img class='resize-listener' alt='' src='<%- ctx.post.contentUrl %>'/>
+        <% if (ctx.post.mimeType === 'image/vnd.adobe.photoshop') { %>
+            <img class='resize-listener' alt='' src='<%- ctx.post.thumbnailUrl %>'/>
+        <% } else { %>
+            <img class='resize-listener' alt='' src='<%- ctx.post.contentUrl %>'/>
+        <% } %>
 
     <% } else if (ctx.post.type === 'flash') { %>
 

--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -13,6 +13,7 @@
                     'image/avif': 'AVIF',
                     'image/heif': 'HEIF',
                     'image/heic': 'HEIC',
+                    'image/vnd.adobe.photoshop': 'PSD',
                     'video/webm': 'WEBM',
                     'video/mp4': 'MPEG-4',
                     'video/quicktime': 'MOV',

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -20,6 +20,7 @@ function _mimeTypeToPostType(mimeType) {
             "image/avif": "image",
             "image/heif": "image",
             "image/heic": "image",
+            "image/vnd.adobe.photoshop": "image",
             "video/mp4": "video",
             "video/webm": "video",
             "video/quicktime": "video",
@@ -165,7 +166,7 @@ class PostUploadView extends events.EventTarget {
             this._contentInputNode,
             {
                 extraText:
-                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic",
+                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic, .psd",
                 allowUrls: true,
                 allowMultiple: true,
                 lock: false,

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,12 @@
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION=3.16
 
-
-FROM alpine:$ALPINE_VERSION as prereqs
+#######################################
+# Base Stage (prereqs)
+#######################################
+FROM alpine:$ALPINE_VERSION AS prereqs
 WORKDIR /opt/app
 
+# Install system dependencies (Python, development packages, and runtime libraries)
 RUN apk --no-cache add \
         python3 \
         python3-dev \
@@ -13,31 +16,47 @@ RUN apk --no-cache add \
         libheif-dev \
         libavif \
         libavif-dev \
+        freetype-dev \
         ffmpeg \
+        lapack \
+        lapack-dev \
         # from requirements.txt:
         py3-yaml \
         py3-psycopg2 \
-        py3-sqlalchemy \
         py3-certifi \
-        py3-numpy \
-        py3-pillow \
         py3-pynacl \
         py3-tz \
         py3-pyrfc3339
+
+# Install pip-only packages, using a wheel to avoid building scikit-image
+RUN pip3 install --no-cache-dir wheel
+
 RUN pip3 install --no-cache-dir --disable-pip-version-check \
+        --extra-index-url https://alpine-wheels.github.io/index \
+        "aggdraw==1.3.12" \
         "alembic>=0.8.5" \
+        "attrs==25.1.0" \
         "coloredlogs==5.0" \
         "pyheif==0.6.1" \
         "heif-image-plugin>=0.3.2" \
         yt-dlp \
-        "pillow-avif-plugin~=1.1.0"
+        "pillow>=6.1.0" \
+        "pillow-avif-plugin~=1.1.0" \
+        "psd-tools==1.10.4" \
+        "numpy==1.21.6" \
+        "scikit-image==0.19.3" \
+        "scipy==1.8.0" \
+        "sqlalchemy==1.3.21"
+
 RUN apk --no-cache del py3-pip
 
 COPY ./ /opt/app/
 RUN rm -rf /opt/app/szurubooru/tests
 
-
-FROM --platform=$BUILDPLATFORM prereqs as testing
+#######################################
+# Testing Stage
+#######################################
+FROM --platform=$BUILDPLATFORM prereqs AS testing
 WORKDIR /opt/app
 
 RUN apk --no-cache add \
@@ -60,8 +79,10 @@ USER app
 ENTRYPOINT ["pytest", "--tb=short"]
 CMD ["szurubooru/"]
 
-
-FROM prereqs as release
+#######################################
+# Release Stage
+#######################################
+FROM prereqs AS release
 WORKDIR /opt/app
 
 ARG PUID=1000

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,15 +1,20 @@
+aggdraw==1.3.12
 alembic>=0.8.5
+attrs==25.1.0
 certifi>=2017.11.5
 coloredlogs==5.0
-heif-image-plugin==0.3.2
-numpy>=1.8.2
+heif-image-plugin>=0.3.2
+numpy>=1.21.6
 pillow-avif-plugin~=1.1.0
-pillow>=4.3.0
+pillow>=6.1.0
+psd-tools==1.10.4
 psycopg2-binary>=2.6.1
 pyheif==0.6.1
 pynacl>=1.2.1
 pyRFC3339>=1.0
 pytz>=2018.3
 pyyaml>=3.11
-SQLAlchemy>=1.0.12, <1.4
+scikit-image==0.19.3
+scipy==1.8.0
+SQLAlchemy==1.3.21
 yt-dlp

--- a/server/szurubooru/func/mime.py
+++ b/server/szurubooru/func/mime.py
@@ -33,6 +33,9 @@ def get_mime_type(content: bytes) -> str:
     if content[4:12] in (b"ftypheic", b"ftypheix"):
         return "image/heic"
 
+    if content[0:4] == b"8BPS":
+        return "image/vnd.adobe.photoshop"
+
     if content[0:4] == b"\x1A\x45\xDF\xA3":
         return "video/webm"
 
@@ -56,6 +59,7 @@ def get_extension(mime_type: str) -> Optional[str]:
         "image/avif": "avif",
         "image/heif": "heif",
         "image/heic": "heic",
+        "image/vnd.adobe.photoshop": "psd",
         "video/mp4": "mp4",
         "video/quicktime": "mov",
         "video/webm": "webm",
@@ -87,6 +91,7 @@ def is_image(mime_type: str) -> bool:
         "image/avif",
         "image/heif",
         "image/heic",
+        "image/vnd.adobe.photoshop",
     )
 
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/97dd9c73-9ff4-4e47-a149-66e11f6e3eba)

This took me like 40 hours of trying to solve the dependency hell caused by the extremely outdated existing dependencies. To be able to use `psd-tools` (and I *had* to use psd-tools, believe me), I had to:

1. Raise alpine to 3.16 from 3.13
2. This broke sqlalchemy, so I had to freeze an older version instead of using the alpine default
3. psd-tools requires scikit-image, which was incompatible with every version of numpy, etc. used in alpine
4. This meant *those* dependencies also had to be frozen to older or newer versions
5. Using wheels allowed me to make the build process way faster, though I still had to do things like open wheels manually to see what versions they expected, check for compatibility again, etc.
6. A benefit of this is that it's less fragile and moving to 3.16 really opens up some new possibilities

The rest was as expected:
- We add .psd to the list of supported formats on every list of formats on client and server.
- A note: since .psd cannot be rendered on browsers, we simply render the thumbnail, which is a still image. This means large psds will look blurry on post view (before you download them), but this can be fixed in the future.

If you consider this too hacky, feel free to not merge, but I'm switching https://homestuck.net/resources/booru/ to this fork until it is. PSD support really is vital for our use case.