### PR TITLE
build: create docker-compose.dev.yml so dev build iteration doesn't take forever

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,4 +1,5 @@
 node_modules/*
+public/
 Dockerfile
 .dockerignore
 **/.gitignore

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,3 +1,26 @@
+FROM --platform=$BUILDPLATFORM node:lts-alpine as development
+WORKDIR /opt/app
+
+RUN apk --no-cache add \
+    dumb-init \
+    nginx \
+    git
+
+RUN ln -sf /opt/app/nginx.conf.docker /etc/nginx/nginx.conf
+RUN rm -rf /var/www
+RUN ln -sf /opt/app/public/ /var/www
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+ARG BUILD_INFO="docker-development"
+ENV BUILD_INFO=${BUILD_INFO}
+ENV BACKEND_HOST="server"
+
+CMD ["/opt/app/docker-start-dev.sh"]
+VOLUME ["/data"]
+
+
 FROM --platform=$BUILDPLATFORM node:lts as builder
 WORKDIR /opt/app
 

--- a/client/build.js
+++ b/client/build.js
@@ -315,7 +315,7 @@ function makeOutputDirs() {
 }
 
 function watch() {
-    let wss = new WebSocket.Server({ port: 8080 });
+    let wss = new WebSocket.Server({ port: environment === "development" ? 8081 : 8080 });
     const liveReload = !process.argv.includes('--no-live-reload');
 
     function emitReload() {

--- a/client/docker-start-dev.sh
+++ b/client/docker-start-dev.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/dumb-init /bin/sh
+
+# Integrate environment variables
+sed -i "s|__BACKEND__|${BACKEND_HOST}|" \
+  /etc/nginx/nginx.conf
+
+# Start server
+nginx &
+
+# Watch source for changes and build app
+# FIXME: It's not ergonomic to run `npm i` outside of the build step.
+#        However, the mounting of different directories into the
+#        client container's /opt/app causes node_modules to disappear
+#          (the mounting causes client/Dockerfile's RUN npm install
+#           to silently clobber).
+#        Find a way to move `npm i` into client/Dockerfile.
+npm i && npm run watch -- --polling

--- a/client/docker-start.sh
+++ b/client/docker-start.sh
@@ -2,10 +2,10 @@
 
 # Integrate environment variables
 sed -i "s|__BACKEND__|${BACKEND_HOST}|" \
-    /etc/nginx/nginx.conf
+  /etc/nginx/nginx.conf
 sed -i "s|__BASEURL__|${BASE_URL:-/}|g" \
-    /var/www/index.htm \
-    /var/www/manifest.json
+  /var/www/index.htm \
+  /var/www/manifest.json
 
 # Start server
 exec nginx

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -3,7 +3,7 @@
 const config = require("./config.js");
 
 if (config.environment == "development") {
-    var ws = new WebSocket("ws://" + location.hostname + ":8080");
+    var ws = new WebSocket("ws://" + location.hostname + ":8081");
     ws.addEventListener("open", function (event) {
         console.log("Live-reloading websocket connected.");
     });

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,54 @@
+## Docker Compose configuration for dev iteration
+##
+## Data is transient by using named vols.
+## Run: docker-compose -f ./docker-compose.dev.yml up
+services:
+
+  server:
+    build:
+      context: ./server
+      target: development
+    depends_on:
+      - sql
+    environment:
+      ## These should be the names of the dependent containers listed below,
+      ## or FQDNs/IP addresses if these services are running outside of Docker
+      POSTGRES_HOST: sql
+      ## Credentials for database:
+      POSTGRES_USER:
+      POSTGRES_PASSWORD:
+      ## Commented Values are Default:
+      #POSTGRES_DB: defaults to same as POSTGRES_USER
+      #POSTGRES_PORT: 5432
+      #LOG_SQL: 0 (1 for verbose SQL logs)
+      THREADS:
+    volumes:
+      - "data:/data"
+      - "./server/:/opt/app/"
+
+  client:
+    build:
+      context: ./client
+      target: development
+    depends_on:
+      - server
+    volumes:
+      - "data:/data:ro"
+      - "./client/:/opt/app/"
+      - "/opt/app/public/"
+    ports:
+      - "${PORT}:80"
+      - "8081:8081"
+
+  sql:
+    image: postgres:11-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:
+      POSTGRES_PASSWORD:
+    volumes:
+      - "sql:/var/lib/postgresql/data"
+
+volumes:
+  data:
+  sql:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -61,7 +61,42 @@ ENTRYPOINT ["pytest", "--tb=short"]
 CMD ["szurubooru/"]
 
 
+FROM prereqs as development
+WORKDIR /opt/app
+
+ARG PUID=1000
+ARG PGID=1000
+
+RUN apk --no-cache add \
+    dumb-init \
+    py3-pip \
+    py3-setuptools \
+    py3-waitress \
+    && pip3 install --no-cache-dir --disable-pip-version-check \
+    hupper \
+    && mkdir -p /opt/app /data \
+    && addgroup -g ${PGID} app \
+    && adduser -SDH -h /opt/app -g '' -G app -u ${PUID} app \
+    && chown -R app:app /opt/app /data
+
+USER app
+CMD ["/opt/app/docker-start-dev.sh"]
+
+ARG PORT=6666
+ENV PORT=${PORT}
+EXPOSE ${PORT}
+
+ARG THREADS=4
+ENV THREADS=${THREADS}
+
+VOLUME ["/data/"]
+
+
 FROM prereqs as release
+
+COPY ./ /opt/app/
+RUN rm -rf /opt/app/szurubooru/tests
+
 WORKDIR /opt/app
 
 ARG PUID=1000

--- a/server/docker-start-dev.sh
+++ b/server/docker-start-dev.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/dumb-init /bin/sh
+set -e
+cd /opt/app
+
+alembic upgrade head
+
+echo "Starting szurubooru API on port ${PORT} - Running on ${THREADS} threads"
+exec hupper -m waitress --port ${PORT} --threads ${THREADS} szurubooru.facade:app


### PR DESCRIPTION
Earlier, [neobooru started work](https://github.com/neobooru/szurubooru/blob/docker-development-setup) to create a `docker-compose.dev.yml` for rapid hot-reloadable development in response to #395.

This commit should cleanly merge `docker-development-setup` into the current `master`, adding and fixing anything missing while keeping the scope of the change as small as possible.

Compared to downstream's branch, this commit
* Excludes extraneous changes such as
    * Any formatting
    * The use of [deprecated](https://docs.docker.com/reference/compose-file/version-and-name/)/ineffectual top-level `version:` in composer files
* Supports controlling `$THREADS`
* Respects currently used `FROM` statements, yadayada

## limitations

The volume mounting setup during the `client, target development` Docker build step causes `node_modules` to disappear. To ensure that `node_modules` are present at runtime I simply run `npm i` before any given `npm run watch` in `client/docker-start-dev.sh`.

This commit doesn't add docs yet :-) but it should be along the lines of a simple

```bash
docker compose -f ./docker-compose.dev.yml up
```