### PR TITLE
server/rest: unescape percent-encoded route parameters

### DIFF
--- a/server/szurubooru/rest/app.py
+++ b/server/szurubooru/rest/app.py
@@ -101,7 +101,7 @@ def application(
                 for hook in middleware.pre_hooks:
                     hook(ctx)
                 try:
-                    response = handler(ctx, match.groupdict())
+                    response = handler(ctx, {k: urllib.parse.unquote(v) for k, v in match.groupdict().items()})
                 except Exception:
                     ctx.session.rollback()
                     raise


### PR DESCRIPTION
Some routes that address things by name instead of ID, e.g. /tag/tagname, where we allow special characters, need params to be unescaped.

For example a tag of `[test]` gets encoded by the frontend into `/tag/%5Btest%5D`, you can find this link in the tag listing. (/tags)
Previously, we would get an error saying `Tag ‘%5Btest%5D’ not found.`
We allow any non-space character inside of tag names, so decode them properly.

I don't believe this negatively affects any other part of the code, and it doesn't affect SEO (I was worried about duplicate pages but turns out even Github allows unnecessarily url encoded paths so it shouldn't be an issue).