### PR TITLE
server/snapshots: treat invalid users as anonymous

### DIFF
--- a/server/szurubooru/func/snapshots.py
+++ b/server/szurubooru/func/snapshots.py
@@ -107,6 +107,9 @@ def _create(
         entity
     )
 
+    if auth_user and not auth_user.name:
+        auth_user = None
+
     snapshot = model.Snapshot()
     snapshot.creation_time = datetime.utcnow()
     snapshot.operation = operation


### PR DESCRIPTION
Fixes the crash described in #682
Tag creation worked for new posts by anonymous users, but not with new tags on an existing post.
Untested so there may be other unaddressed issues with anonymous tagging.

@CrawlerBleak