### PR TITLE
server/tags: prevent creation of "." and ".." tags

### DIFF
--- a/server/szurubooru/func/tags.py
+++ b/server/szurubooru/func/tags.py
@@ -42,6 +42,8 @@ def _verify_name_validity(name: str) -> None:
     name_regex = config.config["tag_name_regex"]
     if not re.match(name_regex, name):
         raise InvalidTagNameError("Name must satisfy regex %r." % name_regex)
+    if name in [".", ".."]:
+        raise InvalidTagNameError(f"Tag `{name}` is not allowed.")
 
 
 def _get_names(tag: model.Tag) -> List[str]:


### PR DESCRIPTION
cf. #521, #390
Previously this check was only done on the client. The API operates on tag slugs, and these special strings cause issues with web servers.