### PR TITLE
Autocomplete tweaks

### DIFF
--- a/client/css/core-forms.styl
+++ b/client/css/core-forms.styl
@@ -369,6 +369,7 @@ input[type=file]:focus+.file-dropper,
             a
                 display: block
                 padding: 0.1em 0.5em
+                transition: none
             &.active a, a:hover
                 background: $button-enabled-background-color
                 color: $button-enabled-text-color

--- a/client/js/controllers/pool_list_controller.js
+++ b/client/js/controllers/pool_list_controller.js
@@ -104,7 +104,8 @@ class PoolListController {
                     this._ctx.parameters.query,
                     offset,
                     limit,
-                    fields
+                    fields,
+                    {}
                 );
             },
             pageRenderer: (pageCtx) => {

--- a/client/js/controllers/tag_list_controller.js
+++ b/client/js/controllers/tag_list_controller.js
@@ -78,7 +78,8 @@ class TagListController {
                     this._ctx.parameters.query,
                     offset,
                     limit,
-                    fields
+                    fields,
+                    {}
                 );
             },
             pageRenderer: (pageCtx) => {

--- a/client/js/controls/auto_complete_control.js
+++ b/client/js/controls/auto_complete_control.js
@@ -63,11 +63,18 @@ class AutoCompleteControl {
             prefix = this._sourceInputNode.value.substring(0, index + 1);
             middle = this._sourceInputNode.value.substring(index + 1);
         }
+        suffix = spaceIndex < commaIndex ? suffix.replace(/^[^,]+/, "") : suffix.replace(/^\S+/, "");
+        suffix = suffix.trimLeft();
         this._sourceInputNode.value =
-            prefix + result.toString() + delimiter + suffix.trimLeft();
+            prefix + result.toString() + delimiter + suffix;
         if (!addSpace) {
-            this._sourceInputNode.value = this._sourceInputNode.value.trim();
+            this._sourceInputNode.value = this._sourceInputNode.value.trimLeft();
         }
+        const selection = this._sourceInputNode.value.length - suffix.length;
+        if (!addSpace) {
+            this._sourceInputNode.value = this._sourceInputNode.value.trimRight();
+        }
+        this._sourceInputNode.setSelectionRange(selection, selection);
         this._sourceInputNode.focus();
     }
 

--- a/client/js/controls/auto_complete_control.js
+++ b/client/js/controls/auto_complete_control.js
@@ -223,6 +223,13 @@ class AutoCompleteControl {
     }
 
     _updateResults(textToFind) {
+        if (this._options.isNegationAllowed && textToFind === "-") {
+            this._results = [];
+            this._activeResult = -1;
+            this._refreshList();
+            return;
+        }
+
         this._options.getMatches(textToFind).then((matches) => {
             const oldResults = this._results.slice();
             this._results = matches.slice(0, this._options.maxResults);

--- a/client/js/controls/pool_auto_complete_control.js
+++ b/client/js/controls/pool_auto_complete_control.js
@@ -10,8 +10,7 @@ function _poolListToMatches(text, pools, options) {
             return pool2.postCount - pool1.postCount;
         })
         .map((pool) => {
-            pool.matchingNames = pool.names.filter((name) => misc.wildcardMatch(text + "*", name, false));
-            pool.matchingNames = pool.matchingNames.length ? pool.matchingNames : pool.names;
+            pool.matchingNames = misc.matchingNames(text, pool.names);
             let cssName = misc.makeCssName(pool.category, "pool");
             const caption =
                 '<span class="' +
@@ -64,8 +63,7 @@ class PoolAutoCompleteControl extends AutoCompleteControl {
         }
         const result = this._results[this._activeResult].value;
         const textToFind = this._options.getTextToFind();
-        result.matchingNames = result.names.filter((name) => misc.wildcardMatch(textToFind + "*", name, false));
-        result.matchingNames = result.matchingNames.length ? result.matchingNames : result.names;
+        result.matchingNames = misc.matchingNames(textToFind, result.names);
         return result;
     }
 }

--- a/client/js/controls/pool_auto_complete_control.js
+++ b/client/js/controls/pool_auto_complete_control.js
@@ -31,9 +31,9 @@ class PoolAutoCompleteControl extends AutoCompleteControl {
         options.getMatches = (text) => {
             const term = misc.escapeSearchTerm(text);
             const query =
-                (text.length < minLengthForPartialSearch
-                    ? term + "*"
-                    : "*" + term + "*") + " sort:post-count";
+                (text.length >= minLengthForPartialSearch
+                    ? "*" + term + "*"
+                    : term + "*") + " sort:post-count";
 
             return new Promise((resolve, reject) => {
                 PoolList.search(query, 0, this._options.maxResults, [

--- a/client/js/controls/pool_auto_complete_control.js
+++ b/client/js/controls/pool_auto_complete_control.js
@@ -42,7 +42,8 @@ class PoolAutoCompleteControl extends AutoCompleteControl {
                     "category",
                     "postCount",
                     "version",
-                ]).then(
+                ],
+                { noProgress: true }).then(
                     (response) =>
                         resolve(
                             _poolListToMatches(response.results, this._options)

--- a/client/js/controls/pool_auto_complete_control.js
+++ b/client/js/controls/pool_auto_complete_control.js
@@ -4,18 +4,20 @@ const misc = require("../util/misc.js");
 const PoolList = require("../models/pool_list.js");
 const AutoCompleteControl = require("./auto_complete_control.js");
 
-function _poolListToMatches(pools, options) {
+function _poolListToMatches(text, pools, options) {
     return [...pools]
         .sort((pool1, pool2) => {
             return pool2.postCount - pool1.postCount;
         })
         .map((pool) => {
+            pool.matchingNames = pool.names.filter((name) => misc.wildcardMatch(text + "*", name, false));
+            pool.matchingNames = pool.matchingNames.length ? pool.matchingNames : pool.names;
             let cssName = misc.makeCssName(pool.category, "pool");
             const caption =
                 '<span class="' +
                 cssName +
                 '">' +
-                misc.escapeHtml(pool.names[0] + " (" + pool.postCount + ")") +
+                misc.escapeHtml(pool.matchingNames[0] + " (" + pool.postCount + ")") +
                 "</span>";
             return {
                 caption: caption,
@@ -46,7 +48,7 @@ class PoolAutoCompleteControl extends AutoCompleteControl {
                 { noProgress: true }).then(
                     (response) =>
                         resolve(
-                            _poolListToMatches(response.results, this._options)
+                            _poolListToMatches(text, response.results, this._options)
                         ),
                     reject
                 );
@@ -54,6 +56,17 @@ class PoolAutoCompleteControl extends AutoCompleteControl {
         };
 
         super(input, options);
+    }
+
+    _getActiveSuggestion() {
+        if (this._activeResult === -1) {
+            return null;
+        }
+        const result = this._results[this._activeResult].value;
+        const textToFind = this._options.getTextToFind();
+        result.matchingNames = result.names.filter((name) => misc.wildcardMatch(textToFind + "*", name, false));
+        result.matchingNames = result.matchingNames.length ? result.matchingNames : result.names;
+        return result;
     }
 }
 

--- a/client/js/controls/tag_auto_complete_control.js
+++ b/client/js/controls/tag_auto_complete_control.js
@@ -64,7 +64,8 @@ class TagAutoCompleteControl extends AutoCompleteControl {
                     "names",
                     "category",
                     "usages",
-                ]).then(
+                ],
+                { noProgress: true }).then(
                     (response) =>
                         resolve(
                             _tagListToMatches(response.results, this._options, negated)

--- a/client/js/controls/tag_auto_complete_control.js
+++ b/client/js/controls/tag_auto_complete_control.js
@@ -11,8 +11,7 @@ function _tagListToMatches(text, tags, options, negated) {
             return tag2.usages - tag1.usages;
         })
         .map((tag) => {
-            tag.matchingNames = tag.names.filter((name) => misc.wildcardMatch(text + "*", name, false));
-            tag.matchingNames = tag.matchingNames.length ? tag.matchingNames : tag.names;
+            tag.matchingNames = misc.matchingNames(text, tag.names);
             let cssName = misc.makeCssName(tag.category, "tag");
             if (options.isTaggedWith(tag.names[0])) {
                 cssName += " disabled";
@@ -87,8 +86,7 @@ class TagAutoCompleteControl extends AutoCompleteControl {
         }
         const result = this._results[this._activeResult].value;
         const textToFind = this._options.getTextToFind();
-        result.matchingNames = result.names.filter((name) => misc.wildcardMatch(textToFind + "*", name, false));
-        result.matchingNames = result.matchingNames.length ? result.matchingNames : result.names;
+        result.matchingNames = misc.matchingNames(textToFind, result.names);
         return result;
     }
 }

--- a/client/js/controls/tag_input_control.js
+++ b/client/js/controls/tag_input_control.js
@@ -111,6 +111,7 @@ class TagInputControl extends events.EventTarget {
                 },
                 verticalShift: -2,
                 isTaggedWith: (tagName) => this.tags.isTaggedWith(tagName),
+                isNegationAllowed: false,
             }
         );
 

--- a/client/js/models/pool_list.js
+++ b/client/js/models/pool_list.js
@@ -6,7 +6,7 @@ const AbstractList = require("./abstract_list.js");
 const Pool = require("./pool.js");
 
 class PoolList extends AbstractList {
-    static search(text, offset, limit, fields) {
+    static search(text, offset, limit, fields, options) {
         return api
             .get(
                 uri.formatApiLink("pools", {
@@ -14,7 +14,8 @@ class PoolList extends AbstractList {
                     offset: offset,
                     limit: limit,
                     fields: fields.join(","),
-                })
+                }),
+                options
             )
             .then((response) => {
                 return Promise.resolve(

--- a/client/js/models/tag_list.js
+++ b/client/js/models/tag_list.js
@@ -6,7 +6,7 @@ const AbstractList = require("./abstract_list.js");
 const Tag = require("./tag.js");
 
 class TagList extends AbstractList {
-    static search(text, offset, limit, fields) {
+    static search(text, offset, limit, fields, options) {
         return api
             .get(
                 uri.formatApiLink("tags", {
@@ -14,7 +14,8 @@ class TagList extends AbstractList {
                     offset: offset,
                     limit: limit,
                     fields: fields.join(","),
-                })
+                }),
+                options
             )
             .then((response) => {
                 return Promise.resolve(

--- a/client/js/util/misc.js
+++ b/client/js/util/misc.js
@@ -216,6 +216,18 @@ function wildcardMatch(pattern, str, sensitive = false) {
     return re.test(str);
 }
 
+function matchingNames(text, names) {
+    const minLengthForPartialSearch = 3;
+    let matches = names.filter((name) => wildcardMatch(text + "*", name, false));
+
+    if (!matches.length && text.length >= minLengthForPartialSearch) {
+        matches = names.filter((name) => wildcardMatch("*" + text + "*", name, false));
+    }
+
+    matches = matches.length ? matches : names;
+    return matches;
+}
+
 module.exports = {
     range: range,
     formatRelativeTime: formatRelativeTime,
@@ -236,4 +248,5 @@ module.exports = {
     getPrettyName: getPrettyName,
     preloadPostImages: preloadPostImages,
     wildcardMatch: wildcardMatch,
+    matchingNames: matchingNames,
 };

--- a/client/js/util/misc.js
+++ b/client/js/util/misc.js
@@ -210,6 +210,12 @@ function preloadPostImages(post) {
     img.src = post.contentUrl;
 }
 
+function wildcardMatch(pattern, str, sensitive = false) {
+    let w = pattern.replace(/[.+^${}()|[\]\\?]/g, "\\$&");
+    const re = new RegExp(`^${w.replace(/\(--wildcard--\)|\*/g, ".*")}$`, sensitive ? "" : "i");
+    return re.test(str);
+}
+
 module.exports = {
     range: range,
     formatRelativeTime: formatRelativeTime,
@@ -229,4 +235,5 @@ module.exports = {
     dataURItoBlob: dataURItoBlob,
     getPrettyName: getPrettyName,
     preloadPostImages: preloadPostImages,
+    wildcardMatch: wildcardMatch,
 };

--- a/client/js/views/home_view.js
+++ b/client/js/views/home_view.js
@@ -30,6 +30,7 @@ class HomeView {
                             misc.escapeSearchTerm(tag.names[0]),
                             true
                         ),
+                    isNegationAllowed: true,
                 }
             );
             this._formNode.addEventListener("submit", (e) =>

--- a/client/js/views/home_view.js
+++ b/client/js/views/home_view.js
@@ -27,7 +27,7 @@ class HomeView {
                 {
                     confirm: (tag) =>
                         this._autoCompleteControl.replaceSelectedText(
-                            misc.escapeSearchTerm(tag.names[0]),
+                            misc.escapeSearchTerm(tag.matchingNames[0]),
                             true
                         ),
                     isNegationAllowed: true,

--- a/client/js/views/pool_merge_view.js
+++ b/client/js/views/pool_merge_view.js
@@ -25,7 +25,7 @@ class PoolMergeView extends events.EventTarget {
                     confirm: (pool) => {
                         this._targetPoolId = pool.id;
                         this._autoCompleteControl.replaceSelectedText(
-                            pool.names[0],
+                            pool.matchingNames[0],
                             false
                         );
                     },

--- a/client/js/views/pools_header_view.js
+++ b/client/js/views/pools_header_view.js
@@ -21,7 +21,7 @@ class PoolsHeaderView extends events.EventTarget {
                 {
                     confirm: (pool) =>
                         this._autoCompleteControl.replaceSelectedText(
-                            misc.escapeSearchTerm(pool.names[0]),
+                            misc.escapeSearchTerm(pool.matchingNames[0]),
                             true
                         ),
                 }

--- a/client/js/views/posts_header_view.js
+++ b/client/js/views/posts_header_view.js
@@ -186,6 +186,7 @@ class PostsHeaderView extends events.EventTarget {
                         misc.escapeSearchTerm(tag.names[0]),
                         true
                     ),
+                isNegationAllowed: true,
             }
         );
 

--- a/client/js/views/posts_header_view.js
+++ b/client/js/views/posts_header_view.js
@@ -183,7 +183,7 @@ class PostsHeaderView extends events.EventTarget {
             {
                 confirm: (tag) =>
                     this._autoCompleteControl.replaceSelectedText(
-                        misc.escapeSearchTerm(tag.names[0]),
+                        misc.escapeSearchTerm(tag.matchingNames[0]),
                         true
                     ),
                 isNegationAllowed: true,

--- a/client/js/views/tag_merge_view.js
+++ b/client/js/views/tag_merge_view.js
@@ -23,7 +23,7 @@ class TagMergeView extends events.EventTarget {
                 {
                     confirm: (tag) =>
                         this._autoCompleteControl.replaceSelectedText(
-                            tag.names[0],
+                            tag.matchingNames[0],
                             false
                         ),
                 }

--- a/client/js/views/tags_header_view.js
+++ b/client/js/views/tags_header_view.js
@@ -21,7 +21,7 @@ class TagsHeaderView extends events.EventTarget {
                 {
                     confirm: (tag) =>
                         this._autoCompleteControl.replaceSelectedText(
-                            misc.escapeSearchTerm(tag.names[0]),
+                            misc.escapeSearchTerm(tag.matchingNames[0]),
                             true
                         ),
                 }


### PR DESCRIPTION
- Autocompletion for negated tags (fixes #432)
- Better behavior for autocomplete in the middle of an already typed tag (replace current word, old behavior would split tag names down the middle)
- More sensible cursor positions after autocomplete (previously would always jump to the end even when completing from the middle of the query)
- Autocomplete the tag alias the user actually searched for (previously it would always use the first alias, which is confusing)
- Don't flash the progress indicator for tag/pool name autocomplete