### PR TITLE
client/markdown: prevent arbitrary HTML

### DIFF
--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -143,6 +143,7 @@ function formatMarkdown(text) {
         renderer: renderer,
         breaks: true,
         smartypants: true,
+        headerIds: false,
     };
     let wrappers = [
         new SjisWrapper(),
@@ -172,6 +173,7 @@ function formatInlineMarkdown(text) {
         renderer: renderer,
         breaks: true,
         smartypants: true,
+        headerIds: false,
     };
     let wrappers = [
         new TildeWrapper(),

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -110,24 +110,22 @@ class StrikeThroughWrapper extends BaseMarkdownWrapper {
     }
 }
 
-function createRenderer() {
-    function sanitize(str) {
-        return str.replace(/&<"/g, (m) => {
-            if (m === "&") {
-                return "&amp;";
-            }
-            if (m === "<") {
-                return "&lt;";
-            }
-            return "&quot;";
-        });
-    }
+function escapeHtml(unsafe) {
+    return unsafe
+        .toString()
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+}
 
+function createRenderer() {
     const renderer = new marked.Renderer();
     renderer.image = (href, title, alt) => {
         let [_, url, width, height] =
             /^(.+?)(?:\s=\s*(\d*)\s*x\s*(\d*)\s*)?$/.exec(href);
-        let res = '<img src="' + sanitize(url) + '" alt="' + sanitize(alt);
+        let res = '<img src="' + escapeHtml(url) + '" alt="' + escapeHtml(alt);
         if (width) {
             res += '" width="' + width;
         }
@@ -156,6 +154,7 @@ function formatMarkdown(text) {
         new SmallWrapper(),
         new StrikeThroughWrapper(),
     ];
+    text = escapeHtml(text);
     for (let wrapper of wrappers) {
         text = wrapper.preprocess(text);
     }
@@ -182,6 +181,7 @@ function formatInlineMarkdown(text) {
         new SmallWrapper(),
         new StrikeThroughWrapper(),
     ];
+    text = escapeHtml(text);
     for (let wrapper of wrappers) {
         text = wrapper.preprocess(text);
     }
@@ -196,4 +196,5 @@ function formatInlineMarkdown(text) {
 module.exports = {
     formatMarkdown: formatMarkdown,
     formatInlineMarkdown: formatInlineMarkdown,
+    escapeHtml: escapeHtml,
 };

--- a/client/js/util/misc.js
+++ b/client/js/util/misc.js
@@ -156,16 +156,6 @@ function makeCssName(text, suffix) {
     return suffix + "-" + text.replace(/[^a-z0-9]/g, "_");
 }
 
-function escapeHtml(unsafe) {
-    return unsafe
-        .toString()
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&apos;");
-}
-
 function arraysDiffer(source1, source2, orderImportant) {
     source1 = [...source1];
     source2 = [...source2];
@@ -221,7 +211,7 @@ module.exports = {
     enableExitConfirmation: enableExitConfirmation,
     disableExitConfirmation: disableExitConfirmation,
     confirmPageExit: confirmPageExit,
-    escapeHtml: escapeHtml,
+    escapeHtml: markdown.escapeHtml,
     makeCssName: makeCssName,
     splitByWhitespace: splitByWhitespace,
     arraysDiffer: arraysDiffer,


### PR DESCRIPTION
Introduced in 0137cf383a81e0a2a0f5db7c2ded4b4a55c5e2fc, anywhere that allows markdown e.g. comments allowed any arbitrary tag that wasn't explicitly banned by DOMPurify, since it cannot know whether it came from our Markdown renderer or from the user.
People could add arbitrary <style> tags that mess with the page, \<button>s etc. It did not lead to XSS since DOMPurify strips it, but still unacceptable.
Also, the sanitize function inside createRenderer had a broken regex and wouldn't actually sanitize anything, it's now replaced with our existing (and working) function.

escapeHtml is identical to the old behavior of marked.js sanitize=true
Had to move the function from misc.js into markdown.js to avoid circular imports.

I want to replace all HTML handling with modern DOM operations in a future PR.