### PR TITLE
client/markdown: small fixes and improvements

### DIFF
--- a/client/html/help_comments.tpl
+++ b/client/html/help_comments.tpl
@@ -26,6 +26,10 @@
             <td><code>[sjis](´･ω･`)[/sjis]</td>
             <td>adds SJIS art</td>
         </tr>
+        <tr>
+            <td><code>[icon]https://youtube.com[/icon]</td>
+            <td>adds the site icon next to the link</td>
+        </tr>
     </tbody>
 </table>
 

--- a/client/html/help_comments.tpl
+++ b/client/html/help_comments.tpl
@@ -11,6 +11,10 @@
             <td>links to tag &ldquo;Dragon_Ball&rdquo;</td>
         </tr>
         <tr>
+            <td><code>?Hatsune_Miku</code></td>
+            <td>links to tag page for &ldquo;Hatsune_Miku&rdquo;</td>
+        </tr>
+        <tr>
             <td><code>+Pirate</code></td>
             <td>links to user &ldquo;Pirate&rdquo;</td>
         </tr>

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -110,6 +110,15 @@ class StrikeThroughWrapper extends BaseMarkdownWrapper {
     }
 }
 
+class FaviconWrapper extends BaseMarkdownWrapper {
+    preprocess(text) {
+        return text.replace(
+            /\[icon\]((?:[^\[]|\[(?!\/?icon\]))+)\[\/icon\]/gi,
+            "[![$1](https://www.google.com/s2/favicons?domain=$1)]($1) $1"
+        );
+    }
+}
+
 function createRenderer() {
     function sanitize(str) {
         return str.replace(/&<"/g, (m) => {
@@ -155,6 +164,7 @@ function formatMarkdown(text) {
         new SpoilersWrapper(),
         new SmallWrapper(),
         new StrikeThroughWrapper(),
+        new FaviconWrapper(),
     ];
     for (let wrapper of wrappers) {
         text = wrapper.preprocess(text);
@@ -181,6 +191,7 @@ function formatInlineMarkdown(text) {
         new SpoilersWrapper(),
         new SmallWrapper(),
         new StrikeThroughWrapper(),
+        new FaviconWrapper(),
     ];
     for (let wrapper of wrappers) {
         text = wrapper.preprocess(text);

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -51,17 +51,6 @@ class TildeWrapper extends BaseMarkdownWrapper {
     }
 }
 
-// prevent ^#... from being treated as headers, due to tag permalinks
-class TagPermalinkFixWrapper extends BaseMarkdownWrapper {
-    preprocess(text) {
-        return text.replace(/^#/g, "%%%#");
-    }
-
-    postprocess(text) {
-        return text.replace(/%%%#/g, "#");
-    }
-}
-
 // post, user and tags permalinks
 class EntityPermalinkWrapper extends BaseMarkdownWrapper {
     preprocess(text) {
@@ -158,7 +147,6 @@ function formatMarkdown(text) {
     let wrappers = [
         new SjisWrapper(),
         new TildeWrapper(),
-        new TagPermalinkFixWrapper(),
         new EntityPermalinkWrapper(),
         new SearchPermalinkWrapper(),
         new SpoilersWrapper(),

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -116,7 +116,7 @@ class FaviconWrapper extends BaseMarkdownWrapper {
     preprocess(text) {
         return text.replace(
             /\[icon\]((?:[^\[]|\[(?!\/?icon\]))+)\[\/icon\]/gi,
-            "[![$1](https://www.google.com/s2/favicons?domain=$1)]($1) $1"
+            '<a href="$1"><img src="https://www.google.com/s2/favicons?domain=$1"> $1</a>'
         );
     }
 }

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -55,12 +55,16 @@ class TildeWrapper extends BaseMarkdownWrapper {
 class EntityPermalinkWrapper extends BaseMarkdownWrapper {
     preprocess(text) {
         text = text.replace(
-            /(^|^\(|(?:[^\]])\(|[\s<>\[\]\)])([+#@][a-zA-Z0-9_-]+)/g,
-            "$1[$2]($2)"
+            /(?<=(?<!\])\(|[\[<])([+#@?][^\s%#+/]+)(?=[\)\]>])/g, "[$1]($1)"
         );
+
+        text = text.replace(
+            /(?<![\(\[<]|%%%)([+#@?][^\s%#+/]+)(?![\)\]>])/g, "[$1]($1)"
+        );
+
         text = text.replace(/\]\(@(\d+)\)/g, "](/post/$1)");
         text = text.replace(/\]\(\+([a-zA-Z0-9_-]+)\)/g, "](/user/$1)");
-        text = text.replace(/\]\(#([a-zA-Z0-9_-]+)\)/g, "](/posts/query=$1)");
+        text = text.replace(/\]\(#([^\s%+#/]+)\)/g, "](/posts/query=$1)");
         return text;
     }
 }

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -57,13 +57,13 @@ class EntityPermalinkWrapper extends BaseMarkdownWrapper {
         super();
         this.getPrettyName = getPrettyName || ((text) => text);
     }
+    unescape(text) {
+        return text.replace(/\\([^#@+/])/g, "$1");
+    }
     preprocess(text) {
         text = text.replace(
-            /(?<=(?<!\])\(|[\[<])([+#@?][^\s%#+/]+)(?=[\)\]>])/g, "[$1]($1)"
-        );
-
-        text = text.replace(
-            /(?<![\(\[<]|%%%)([+#@?][^\s%#+/]+)(?![\)\]>])/g, "[$1]($1)"
+            /(?<![a-zA-Z0-9])([#+@?](?:[a-zA-Z0-9_-]|\\[^#@+/])+)/g,
+            (_, entity) => `[${this.unescape(entity)}](${this.unescape(entity)})`
         );
 
         text = text.replace(/\]\(@(\d+)\)/g, "](/post/$1)");

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -65,6 +65,9 @@ class EntityPermalinkWrapper extends BaseMarkdownWrapper {
         text = text.replace(/\]\(@(\d+)\)/g, "](/post/$1)");
         text = text.replace(/\]\(\+([a-zA-Z0-9_-]+)\)/g, "](/user/$1)");
         text = text.replace(/\]\(#([^\s%+#/]+)\)/g, "](/posts/query=$1)");
+        text = text.replace(/\[\?([^\s%+#/]+)\]\(\?\1\)/g, (_, tag) => {
+            return `[${tag.replace(/_/g, " ")}](/tag/${tag})`;
+        });
         return text;
     }
 }

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -53,6 +53,10 @@ class TildeWrapper extends BaseMarkdownWrapper {
 
 // post, user and tags permalinks
 class EntityPermalinkWrapper extends BaseMarkdownWrapper {
+    constructor(getPrettyName) {
+        super();
+        this.getPrettyName = getPrettyName || ((text) => text);
+    }
     preprocess(text) {
         text = text.replace(
             /(?<=(?<!\])\(|[\[<])([+#@?][^\s%#+/]+)(?=[\)\]>])/g, "[$1]($1)"
@@ -64,9 +68,11 @@ class EntityPermalinkWrapper extends BaseMarkdownWrapper {
 
         text = text.replace(/\]\(@(\d+)\)/g, "](/post/$1)");
         text = text.replace(/\]\(\+([a-zA-Z0-9_-]+)\)/g, "](/user/$1)");
-        text = text.replace(/\]\(#([^\s%+#/]+)\)/g, "](/posts/query=$1)");
+        text = text.replace(/\[#([^\s%+#/]+)\]\(#\1\)/g, (_, tag) => {
+            return `[#${this.getPrettyName(tag)}](/posts/query=${tag})`;
+        });
         text = text.replace(/\[\?([^\s%+#/]+)\]\(\?\1\)/g, (_, tag) => {
-            return `[${tag.replace(/_/g, " ")}](/tag/${tag})`;
+            return `[${this.getPrettyName(tag)}](/tag/${tag})`;
         });
         return text;
     }
@@ -144,7 +150,7 @@ function createRenderer() {
     return renderer;
 }
 
-function formatMarkdown(text) {
+function formatMarkdown(text, getPrettyName) {
     const renderer = createRenderer();
     const options = {
         renderer: renderer,
@@ -154,7 +160,7 @@ function formatMarkdown(text) {
     let wrappers = [
         new SjisWrapper(),
         new TildeWrapper(),
-        new EntityPermalinkWrapper(),
+        new EntityPermalinkWrapper(getPrettyName),
         new SearchPermalinkWrapper(),
         new SpoilersWrapper(),
         new SmallWrapper(),
@@ -172,7 +178,7 @@ function formatMarkdown(text) {
     return DOMPurify.sanitize(text);
 }
 
-function formatInlineMarkdown(text) {
+function formatInlineMarkdown(text, getPrettyName) {
     const renderer = createRenderer();
     const options = {
         renderer: renderer,
@@ -181,7 +187,7 @@ function formatInlineMarkdown(text) {
     };
     let wrappers = [
         new TildeWrapper(),
-        new EntityPermalinkWrapper(),
+        new EntityPermalinkWrapper(getPrettyName),
         new SearchPermalinkWrapper(),
         new SpoilersWrapper(),
         new SmallWrapper(),

--- a/client/js/util/misc.js
+++ b/client/js/util/misc.js
@@ -95,11 +95,11 @@ function formatRelativeTime(timeString) {
 }
 
 function formatMarkdown(text) {
-    return markdown.formatMarkdown(text);
+    return markdown.formatMarkdown(text, getPrettyName);
 }
 
 function formatInlineMarkdown(text) {
-    return markdown.formatInlineMarkdown(text);
+    return markdown.formatInlineMarkdown(text, getPrettyName);
 }
 
 function splitByWhitespace(str) {


### PR DESCRIPTION
Simple changes to markdown engine to allow use of an `[icon]...[/icon]` tag to insert an icon alongside a link.

This was inspired by danbooru artist pages, which have an easily recognizable icon on the left of the artist's social links, making it way easier to find the links one's looking for. Manually doing this for each artist would be a very tedious matter on a szurubooru instance, so I introduced this tag.

For example, putting `[icon]https://www.youtube.com/watch?v=dQw4w9WgXcQ[/icon]` in a markdown section gets it rendered as
[![https://www.youtube.com/watch?v=dQw4w9WgXcQ](https://www.google.com/s2/favicons?domain=https://www.youtube.com/watch?v=dQw4w9WgXcQ)](https://www.youtube.com/watch?v=dQw4w9WgXcQ) https://www.youtube.com/watch?v=dQw4w9WgXcQ.