### PR TITLE
client/markdown: add tag to show favicon alongside URL

### DIFF
--- a/client/html/help_comments.tpl
+++ b/client/html/help_comments.tpl
@@ -26,6 +26,10 @@
             <td><code>[sjis](´･ω･`)[/sjis]</td>
             <td>adds SJIS art</td>
         </tr>
+        <tr>
+            <td><code>[icon]https://youtube.com[/icon]</td>
+            <td>adds the site icon next to the link</td>
+        </tr>
     </tbody>
 </table>
 

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -110,6 +110,15 @@ class StrikeThroughWrapper extends BaseMarkdownWrapper {
     }
 }
 
+class FaviconWrapper extends BaseMarkdownWrapper {
+    preprocess(text) {
+        return text.replace(
+            /\[icon\]((?:[^\[]|\[(?!\/?icon\]))+)\[\/icon\]/gi,
+            '<a href="$1"><img src="https://www.google.com/s2/favicons?domain=$1"> $1</a>'
+        );
+    }
+}
+
 function createRenderer() {
     function sanitize(str) {
         return str.replace(/&<"/g, (m) => {
@@ -155,6 +164,7 @@ function formatMarkdown(text) {
         new SpoilersWrapper(),
         new SmallWrapper(),
         new StrikeThroughWrapper(),
+        new FaviconWrapper(),
     ];
     for (let wrapper of wrappers) {
         text = wrapper.preprocess(text);
@@ -181,6 +191,7 @@ function formatInlineMarkdown(text) {
         new SpoilersWrapper(),
         new SmallWrapper(),
         new StrikeThroughWrapper(),
+        new FaviconWrapper(),
     ];
     for (let wrapper of wrappers) {
         text = wrapper.preprocess(text);


### PR DESCRIPTION
(Original discussion at #738)

Simple changes to markdown engine to allow use of an [icon]...[/icon] tag to insert an icon alongside a link.

This was inspired by danbooru artist pages, which have an easily recognizable icon on the left of the artist's social links, making it way easier to find the links one's looking for. Manually doing this for each artist would be a very tedious matter on a szurubooru instance, so I introduced this tag.

For example, putting [icon]https://www.youtube.com/watch?v=dQw4w9WgXcQ[/icon] in a markdown section gets it rendered as
https://www.youtube.com/watch?v=dQw4w9WgXcQ https://www.youtube.com/watch?v=dQw4w9WgXcQ.

Huge thanks to @po5 for help with the original PR!