### PR TITLE
server: replace pyheif with pillow-heif, bump alpine version to v3.22

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VERSION=3.13
+ARG ALPINE_VERSION=3.22
 
 
 FROM alpine:$ALPINE_VERSION as prereqs
@@ -24,13 +24,11 @@ RUN apk --no-cache add \
         py3-pynacl \
         py3-tz \
         py3-pyrfc3339
-RUN pip3 install --no-cache-dir --disable-pip-version-check \
+RUN pip3 install --no-cache-dir --disable-pip-version-check --break-system-packages \
         "alembic>=0.8.5" \
         "coloredlogs==5.0" \
-        "pyheif==0.6.1" \
-        "heif-image-plugin>=0.3.2" \
         yt-dlp \
-        "pillow-avif-plugin~=1.1.0"
+        "pillow-heif>=1.0.0"
 RUN apk --no-cache del py3-pip
 
 COPY ./ /opt/app/
@@ -45,7 +43,7 @@ RUN apk --no-cache add \
         py3-pytest \
         py3-pytest-cov \
         postgresql \
- && pip3 install --no-cache-dir --disable-pip-version-check \
+ && pip3 install --no-cache-dir --disable-pip-version-check --break-system-packages \
         pytest-pgsql \
         freezegun \
  && apk --no-cache del py3-pip \
@@ -72,7 +70,7 @@ RUN apk --no-cache add \
     py3-pip \
     py3-setuptools \
     py3-waitress \
-    && pip3 install --no-cache-dir --disable-pip-version-check \
+    && pip3 install --no-cache-dir --disable-pip-version-check --break-system-packages \
     hupper \
     && mkdir -p /opt/app /data \
     && addgroup -g ${PGID} app \

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,12 +1,10 @@
 alembic>=0.8.5
 certifi>=2017.11.5
 coloredlogs==5.0
-heif-image-plugin==0.3.2
 numpy>=1.8.2
-pillow-avif-plugin~=1.1.0
-pillow>=4.3.0
+pillow>=11.2.1
+pillow-heif>=1.0.0
 psycopg2-binary>=2.6.1
-pyheif==0.6.1
 pynacl>=1.2.1
 pyRFC3339>=1.0
 pytz>=2018.3

--- a/server/szurubooru/func/image_hash.py
+++ b/server/szurubooru/func/image_hash.py
@@ -4,13 +4,13 @@ from datetime import datetime
 from io import BytesIO
 from typing import Any, Callable, List, Optional, Set, Tuple
 
-import HeifImagePlugin
+from pillow_heif import register_heif_opener
 import numpy as np
-import pillow_avif
 from PIL import Image
 
 from szurubooru import config, errors
 
+register_heif_opener()
 logger = logging.getLogger(__name__)
 
 # Math based on paper from H. Chi Wong, Marshall Bern and David Goldberg

--- a/server/szurubooru/func/images.py
+++ b/server/szurubooru/func/images.py
@@ -7,14 +7,14 @@ import subprocess
 from io import BytesIO
 from typing import List
 
-import HeifImagePlugin
-import pillow_avif
+from pillow_heif import register_heif_opener
 from PIL import Image as PILImage
 
 from szurubooru import errors
 from szurubooru.func import mime, util
 
 logger = logging.getLogger(__name__)
+register_heif_opener()
 
 
 def convert_heif_to_png(content: bytes) -> bytes:


### PR DESCRIPTION
- Bump alpine to version v3.22
- Replaces pyheif with pillow-heif (pyheif is currently unmaintained upstream and broken with current libheif version)
- removes pillow-avif-plugin requirement due to upstream pillow support

Related to:
- https://github.com/NixOS/nixpkgs/pull/443257
- #745