### PR TITLE
Allow backend & client server to listen on IPv6

### DIFF
--- a/client/nginx.conf.docker
+++ b/client/nginx.conf.docker
@@ -25,7 +25,7 @@ http {
 
     server {
         listen 80 default_server;
-	listen [::]:80 default_server;
+        listen [::]:80 default_server;
 
         location ~ ^/api$ {
             return 302 /api/;

--- a/client/nginx.conf.docker
+++ b/client/nginx.conf.docker
@@ -25,6 +25,7 @@ http {
 
     server {
         listen 80 default_server;
+	listen [::]:80 default_server;
 
         location ~ ^/api$ {
             return 302 /api/;

--- a/server/docker-start-dev.sh
+++ b/server/docker-start-dev.sh
@@ -5,4 +5,4 @@ cd /opt/app
 alembic upgrade head
 
 echo "Starting szurubooru API on port ${PORT} - Running on ${THREADS} threads"
-exec hupper -m waitress --port ${PORT} --threads ${THREADS} szurubooru.facade:app
+exec hupper -m waitress --listen "*:${PORT}" --threads ${THREADS} szurubooru.facade:app

--- a/server/docker-start.sh
+++ b/server/docker-start.sh
@@ -5,4 +5,4 @@ cd /opt/app
 alembic upgrade head
 
 echo "Starting szurubooru API on port ${PORT} - Running on ${THREADS} threads"
-exec waitress-serve-3 --port ${PORT} --threads ${THREADS} szurubooru.facade:app
+exec waitress-serve-3 --listen "*:${PORT}" --threads ${THREADS} szurubooru.facade:app


### PR DESCRIPTION
Currently, the backend & client server does not listen on IPv6 in Docker. This can cause connectivity issues on IPv6-mostly and IPv6-only clusters. The SQL server already listens on both address families.