### PR TITLE
server/net: support outbound socks/http proxies

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -30,7 +30,8 @@ RUN pip3 install --no-cache-dir --disable-pip-version-check \
         "pyheif==0.6.1" \
         "heif-image-plugin>=0.3.2" \
         yt-dlp \
-        "pillow-avif-plugin~=1.1.0"
+        "pillow-avif-plugin~=1.1.0" \
+        "requests[socks]>=2.34.2,<3.0.0"
 RUN apk --no-cache del py3-pip
 
 COPY ./ /opt/app/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -31,7 +31,7 @@ RUN pip3 install --no-cache-dir --disable-pip-version-check \
         "heif-image-plugin>=0.3.2" \
         yt-dlp \
         "pillow-avif-plugin~=1.1.0" \
-        "requests[socks]>=2.34.2,<3.0.0"
+        "requests[socks]>=2.32.4,<3.0.0"
 RUN apk --no-cache del py3-pip
 
 COPY ./ /opt/app/

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -23,6 +23,10 @@ thumbnails:
 user_agent:
 max_dl_filesize: 25.0E+6 # maximum filesize limit in bytes
 
+# Proxy server to use for outbound requests. This is used for the downloader
+# and for direct URL fetches, and optionally for webhooks too (see proxy_webhooks below)
+proxy: # example to use Tor: socks5h://localhost:9050
+
 # automatically convert animated GIF uploads to video formats
 convert:
    gif:
@@ -64,6 +68,9 @@ user_name_regex: '^[a-zA-Z0-9_-]{1,32}$'
 # containing a snapshot resource as JSON. See doc/API.md for details
 webhooks:
     # - https://api.example.com/webhooks/
+# the default is true for safety's sake, however, if you trust the webhook operator
+# with your anonymity, you may set this to false
+proxy_webhooks: true
 
 default_rank: regular
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,5 +11,6 @@ pynacl>=1.2.1
 pyRFC3339>=1.0
 pytz>=2018.3
 pyyaml>=3.11
+requests[socks]>=2.34.2,<3.0.0
 SQLAlchemy>=1.0.12, <1.4
 yt-dlp

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,6 +11,6 @@ pynacl>=1.2.1
 pyRFC3339>=1.0
 pytz>=2018.3
 pyyaml>=3.11
-requests[socks]>=2.34.2,<3.0.0
+requests[socks]>=2.32.4,<3.0.0
 SQLAlchemy>=1.0.12, <1.4
 yt-dlp

--- a/server/szurubooru/func/net.py
+++ b/server/szurubooru/func/net.py
@@ -60,6 +60,11 @@ def download(url: str, use_video_downloader: bool = False) -> bytes:
             "Download target returned HTTP %d. (%s)" % (ex.code, ex.reason),
             extra_fields={"URL": url},
         ) from ex
+    except requests.ConnectionError as ex:
+        raise DownloadError(
+            "General error connecting to server",
+            extra_fields={"URL": url},
+        ) from ex
 
     if (
         youtube_dl_error

--- a/server/szurubooru/func/net.py
+++ b/server/szurubooru/func/net.py
@@ -1,10 +1,10 @@
 import json
 import logging
 import subprocess
-import urllib.error
-import urllib.request
 from threading import Thread
 from typing import Any, Dict, List
+
+import requests
 
 from szurubooru import config, errors
 from szurubooru.func import mime
@@ -30,25 +30,32 @@ def download(url: str, use_video_downloader: bool = False) -> bytes:
         except errors.ThirdPartyError as ex:
             youtube_dl_error = ex
 
-    request = urllib.request.Request(url)
+    headers = {'Referer': url}
     if config.config["user_agent"]:
-        request.add_header("User-Agent", config.config["user_agent"])
-    request.add_header("Referer", url)
+        headers["User-Agent"] = config.config["user_agent"]
 
-    content_buffer = b""
+    proxies = {}
+    if config.config["proxy"]:
+        proxies["http"] = proxies["https"] = config.config["proxy"]
+
+    content_buffer = []
     length_tally = 0
     try:
-        with urllib.request.urlopen(request) as handle:
-            while chunk := handle.read(_dl_chunk_size):
-                length_tally += len(chunk)
-                if length_tally > config.config["max_dl_filesize"]:
-                    raise DownloadTooLargeError(
-                        "Download target exceeds maximum. (%d)"
-                        % (config.config["max_dl_filesize"]),
-                        extra_fields={"URL": url},
-                    )
-                content_buffer += chunk
-    except urllib.error.HTTPError as ex:
+        response = requests.get(url, headers=headers, proxies=proxies, stream=True)
+        response.raise_for_status()
+        for chunk in response.iter_content(
+            chunk_size=_dl_chunk_size,
+            decode_unicode=False,
+        ):
+            length_tally += len(chunk)
+            if length_tally > config.config["max_dl_filesize"]:
+                raise DownloadTooLargeError(
+                    "Download target exceeds maximum. (%d)"
+                    % (config.config["max_dl_filesize"]),
+                    extra_fields={"URL": url},
+                )
+            content_buffer.append(chunk)
+    except requests.HTTPError as ex:
         raise DownloadError(
             "Download target returned HTTP %d. (%s)" % (ex.code, ex.reason),
             extra_fields={"URL": url},
@@ -60,13 +67,15 @@ def download(url: str, use_video_downloader: bool = False) -> bytes:
     ):
         raise youtube_dl_error
 
-    return content_buffer
+    return b"".join(content_buffer)
 
 
 def _get_youtube_dl_content_url(url: str) -> str:
     cmd = ["yt-dlp", "--format", "best", "--no-playlist"]
     if config.config["user_agent"]:
         cmd.extend(["--user-agent", config.config["user_agent"]])
+    if config.config["proxy"]:
+        cmd.extend(["--proxy", config.config["proxy"]])
     cmd.extend(["--get-url", url])
     try:
         return (
@@ -92,19 +101,23 @@ def post_to_webhooks(payload: Dict[str, Any]) -> List[Thread]:
 
 
 def _post_to_webhook(webhook: str, payload: Dict[str, Any]) -> int:
-    req = urllib.request.Request(webhook)
-    req.data = json.dumps(
+    data = json.dumps(
         payload,
         default=lambda x: x.isoformat("T") + "Z",
     ).encode("utf-8")
-    req.add_header("Content-Type", "application/json")
+    headers = {"Content-Type": "application/json"}
+    if config.config["user_agent"]:
+        headers["User-Agent"] = config.config["user_agent"]
+    proxies = {}
+    if config.config["proxy"] and config.config["proxy_webhook"]:
+        proxies["http"] = proxies["https"] = config.config["proxy"]
     try:
-        res = urllib.request.urlopen(req)
-        if not 200 <= res.status <= 299:
+        res = requests.get(webhook, data=data, proxies=proxies, headers=headers)
+        if res.status_code not in range(200, 300):
             logger.warning(
                 f"Webhook {webhook} returned {res.status} {res.reason}"
             )
-        return res.status
-    except urllib.error.URLError as ex:
+        return res.status_code
+    except requests.RequestException as ex:
         logger.warning(f"Unable to call webhook {webhook}: {ex}")
         return 400


### PR DESCRIPTION
If you put (for example) socks5h://localhost:9050 as the proxy,
all outbound requests (yt-dlp and direct fetch) will use Tor. Optionally, the webhook requests will use Tor, but this is optional because the webhook URLs are configured statically by the admin, so it's not always necessary that they be proxied.

To *properly* fix SSRF vulnerabilities (supposing a proxy allows LAN requests), one would need something more advanced with IP address filtering (as [Matrix Synapse](https://github.com/element-hq/synapse) does). Alternatively, a filter can be placed on the entire python process or something (as [0x0.st](https://git.0x0.st/mia/0x0) does, suggesting [FireHOL](https://firehol.org/)).

I tested this code using Tor for upload, webhook, and yt-dlp. I did not test HTTP proxies, but I would be very surprised if yt-dlp supported SOCKS5h proxies and *not* HTTP proxies lol. I also did not run the included tests because I'm not sure how to do it from my OS. If you need me to, I can do it in about a week.