### PR TITLE
Added OIDC Support

### DIFF
--- a/client/css/login-view.styl
+++ b/client/css/login-view.styl
@@ -1,0 +1,12 @@
+#login
+    .oidc-icon
+        height: 2lh
+        width: auto
+        vertical-align: middle
+        margin-right: 0.4em
+
+    .oidc-login-btn
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: inherit;

--- a/client/html/login.tpl
+++ b/client/html/login.tpl
@@ -1,36 +1,54 @@
 <div class='content-wrapper' id='login'>
     <h1>Log in</h1>
-    <form>
-        <ul class='input'>
-            <li>
-                <%= ctx.makeTextInput({
-                    text: 'User name',
-                    name: 'name',
-                    required: true,
-                    pattern: ctx.userNamePattern,
-                }) %>
-            </li>
-            <li>
-                <%= ctx.makePasswordInput({
-                    text: 'Password',
-                    name: 'password',
-                    required: true,
-                    pattern: ctx.passwordPattern,
-                }) %>
-            </li>
-            <li>
-                <%= ctx.makeCheckbox({
-                    text: 'Remember me',
-                    name: 'remember-user',
-                }) %>
-            </li>
-        </ul>
+    <% if (!ctx.disablePasswordAuth) { %>
+        <form>
+            <ul class='input'>
+                <li>
+                    <%= ctx.makeTextInput({
+                        text: 'User name',
+                        name: 'name',
+                        required: true,
+                        pattern: ctx.userNamePattern,
+                    }) %>
+                </li>
+                <li>
+                    <%= ctx.makePasswordInput({
+                        text: 'Password',
+                        name: 'password',
+                        required: true,
+                        pattern: ctx.passwordPattern,
+                    }) %>
+                </li>
+                <li>
+                    <%= ctx.makeCheckbox({
+                        text: 'Remember me',
+                        name: 'remember-user',
+                    }) %>
+                </li>
+            </ul>
 
-        <div class='messages'></div>
+            <div class='messages'></div>
 
-        <div class='buttons'>
-            <input type='submit' value='Log in'/>
-            <a class='append' href='<%- ctx.formatClientLink('password-reset') %>'>Forgot the password?</a>
+            <div class='buttons'>
+                <input type='submit' value='Log in'/>
+                <a class='append' href='<%- ctx.formatClientLink('password-reset') %>'>Forgot the password?</a>
+            </div>
+        </form>
+        <% if (ctx.oidcEnabled) { %>
+            <div class='oidc-login'>
+                <p class='append'>- or -</p>
+                <button type='button' class='oidc-login-btn'>
+                    <% if (ctx.oidcButtonIcon) { %><img src='<%- ctx.oidcButtonIcon %>' alt='' class='oidc-icon'/><% } %>
+                    <%- ctx.oidcButtonLabel %>
+                </button>
+            </div>
+        <% } %>
+    <% } else if (ctx.oidcEnabled) { %>
+        <div class='oidc-login'>
+            <button type='button' class='oidc-login-btn'>
+                <% if (ctx.oidcButtonIcon) { %><img src='<%- ctx.oidcButtonIcon %>' alt='' class='oidc-icon'/><% } %>
+                <%- ctx.oidcButtonLabel %>
+            </button>
         </div>
-    </form>
+    <% } %>
 </div>

--- a/client/js/api.js
+++ b/client/js/api.js
@@ -104,6 +104,22 @@ class Api extends events.EventTarget {
         return !!remoteConfig.canSendMails;
     }
 
+    oidcEnabled() {
+        return !!remoteConfig.oidcEnabled;
+    }
+
+    oidcButtonLabel() {
+        return remoteConfig.oidcButtonLabel || "Log in with SSO";
+    }
+
+    oidcButtonIcon() {
+        return remoteConfig.oidcButtonIcon || null;
+    }
+
+    disablePasswordAuth() {
+        return !!remoteConfig.disablePasswordAuth;
+    }
+
     safetyEnabled() {
         return !!remoteConfig.enableSafety;
     }
@@ -273,6 +289,22 @@ class Api extends events.EventTarget {
 
     isCurrentAuthToken(userToken) {
         return userToken.token === this.token;
+    }
+
+    getOidcAuthorizationUrl() {
+        return this._wrappedRequest("auth/oidc", request.get, {}, {});
+    }
+
+    exchangeOidcCode(code, state) {
+        this.cache = {};
+        return this._wrappedRequest(
+            "auth/oidc",
+            request.post,
+            { code: code, state: state },
+            {}
+        ).then((response) => {
+            return this.loginWithToken(response.userName, response.token, true);
+        });
     }
 
     _getFullUrl(url) {

--- a/client/js/controllers/auth_controller.js
+++ b/client/js/controllers/auth_controller.js
@@ -16,6 +16,21 @@ class LoginController {
 
         this._loginView = new LoginView();
         this._loginView.addEventListener("submit", (e) => this._evtLogin(e));
+        this._loginView.addEventListener("oidcLogin", () =>
+            this._evtOidcLogin()
+        );
+    }
+
+    _evtOidcLogin() {
+        this._loginView.clearMessages();
+        api.getOidcAuthorizationUrl().then(
+            (response) => {
+                window.location.href = response.authorizationUrl;
+            },
+            (error) => {
+                this._loginView.showError(error.message);
+            }
+        );
     }
 
     _evtLogin(e) {

--- a/client/js/controllers/top_navigation_controller.js
+++ b/client/js/controllers/top_navigation_controller.js
@@ -59,7 +59,7 @@ class TopNavigationController {
             }
             topNavigation.hide("login");
         } else {
-            if (!api.hasPrivilege("users:create:self")) {
+            if (!api.hasPrivilege("users:create:self") || api.disablePasswordAuth()) {
                 topNavigation.hide("register");
             }
             topNavigation.hide("account");

--- a/client/js/controllers/user_registration_controller.js
+++ b/client/js/controllers/user_registration_controller.js
@@ -10,6 +10,13 @@ const EmptyView = require("../views/empty_view.js");
 
 class UserRegistrationController {
     constructor() {
+        if (api.disablePasswordAuth()) {
+            this._view = new EmptyView();
+            this._view.showError(
+                "Registration is disabled. Please log in with SSO."
+            );
+            return;
+        }
         if (!api.hasPrivilege("users:create:self")) {
             this._view = new EmptyView();
             this._view.showError("Registration is closed.");

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -100,7 +100,20 @@ Promise.resolve()
             document.body.classList.add("darktheme");
         }
     })
-    .then(() => api.loginFromCookies())
+    .then(() => {
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has("code") && urlParams.has("state")) {
+            const code = urlParams.get("code");
+            const state = urlParams.get("state");
+            window.history.replaceState(
+                {},
+                document.title,
+                window.location.pathname
+            );
+            return api.exchangeOidcCode(code, state);
+        }
+        return api.loginFromCookies();
+    })
     .then(
         () => {
             tags.refreshCategoryColorMap();

--- a/client/js/views/login_view.js
+++ b/client/js/views/login_view.js
@@ -17,31 +17,42 @@ class LoginView extends events.EventTarget {
                 userNamePattern: api.getUserNameRegex(),
                 passwordPattern: api.getPasswordRegex(),
                 canSendMails: api.canSendMails(),
+                oidcEnabled: api.oidcEnabled(),
+                oidcButtonLabel: api.oidcButtonLabel(),
+                oidcButtonIcon: api.oidcButtonIcon(),
+                disablePasswordAuth: api.disablePasswordAuth(),
             })
         );
         views.syncScrollPosition();
 
-        views.decorateValidator(this._formNode);
-        this._userNameInputNode.setAttribute(
-            "pattern",
-            api.getUserNameRegex()
-        );
-        this._passwordInputNode.setAttribute(
-            "pattern",
-            api.getPasswordRegex()
-        );
-        this._formNode.addEventListener("submit", (e) => {
-            e.preventDefault();
-            this.dispatchEvent(
-                new CustomEvent("submit", {
-                    detail: {
-                        name: this._userNameInputNode.value,
-                        password: this._passwordInputNode.value,
-                        remember: this._rememberInputNode.checked,
-                    },
-                })
+        if (this._formNode) {
+            views.decorateValidator(this._formNode);
+            this._userNameInputNode.setAttribute(
+                "pattern",
+                api.getUserNameRegex()
             );
-        });
+            this._passwordInputNode.setAttribute(
+                "pattern",
+                api.getPasswordRegex()
+            );
+            this._formNode.addEventListener("submit", (e) => {
+                e.preventDefault();
+                this.dispatchEvent(
+                    new CustomEvent("submit", {
+                        detail: {
+                            name: this._userNameInputNode.value,
+                            password: this._passwordInputNode.value,
+                            remember: this._rememberInputNode.checked,
+                        },
+                    })
+                );
+            });
+        }
+        if (this._oidcBtnNode) {
+            this._oidcBtnNode.addEventListener("click", () => {
+                this.dispatchEvent(new CustomEvent("oidcLogin"));
+            });
+        }
     }
 
     get _formNode() {
@@ -60,12 +71,20 @@ class LoginView extends events.EventTarget {
         return this._formNode.querySelector("[name=remember-user]");
     }
 
+    get _oidcBtnNode() {
+        return this._hostNode.querySelector(".oidc-login-btn");
+    }
+
     disableForm() {
-        views.disableForm(this._formNode);
+        if (this._formNode) {
+            views.disableForm(this._formNode);
+        }
     }
 
     enableForm() {
-        views.enableForm(this._formNode);
+        if (this._formNode) {
+            views.enableForm(this._formNode);
+        }
     }
 
     clearMessages() {

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -65,6 +65,10 @@ user_name_regex: '^[a-zA-Z0-9_-]{1,32}$'
 webhooks:
     # - https://api.example.com/webhooks/
 
+# default token expiry for all logins, in seconds. 0 means tokens never expire.
+# can be overridden per-login-method (e.g. oidc.expires)
+token_expiry: 0
+
 default_rank: regular
 
 privileges:
@@ -191,6 +195,9 @@ oidc:
     # OIDC claim containing the user's avatar/profile picture URL
     # standard value is 'picture'; leave blank to disable avatar import
     avatar_claim: picture
+    # OIDC login token expiry, in seconds. 0 means no expiry.
+    # Overrides the global token_expiry for OIDC logins. If unset, falls back to token_expiry.
+    expires: 21600
 
 ## ONLY SET THESE IF DEPLOYING OUTSIDE OF DOCKER
 #debug: 0 # generate server logs?

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -169,6 +169,29 @@ privileges:
     'uploads:create':               regular
     'uploads:use_downloader':       power
 
+# OpenID Connect (OIDC) single sign-on
+# Set client_id, client_secret, and issuer to enable SSO login.
+# redirect_uri must be your site's base URL (the SPA root), registered with
+# your OIDC provider exactly as written here.
+oidc:
+    client_id:       # example: my-client
+    client_secret:   # example: mysecret
+    issuer:          # example: https://auth.example.com
+    # must be registered with your OIDC provider and must point to your site root
+    redirect_uri:    # example: https://example.com
+    scopes: 'openid email profile'
+    # set to no to prevent automatic account creation on first OIDC login
+    allow_registration: yes
+    # disable username/password login and self-registration; users must log in via SSO
+    disable_password_auth: no
+    # optional custom label for the SSO button (default: 'Log in with SSO')
+    button_label:
+    # optional URL to an icon image shown on the SSO button
+    button_icon:
+    # OIDC claim containing the user's avatar/profile picture URL
+    # standard value is 'picture'; leave blank to disable avatar import
+    avatar_claim: picture
+
 ## ONLY SET THESE IF DEPLOYING OUTSIDE OF DOCKER
 #debug: 0 # generate server logs?
 #show_sql: 0 # show sql in server logs?

--- a/server/szurubooru/api/__init__.py
+++ b/server/szurubooru/api/__init__.py
@@ -1,4 +1,5 @@
 import szurubooru.api.comment_api
+import szurubooru.api.oidc_api
 import szurubooru.api.info_api
 import szurubooru.api.password_reset_api
 import szurubooru.api.pool_api

--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import Dict, Optional
 
 from szurubooru import config, rest
-from szurubooru.func import auth, posts, users, util
+from szurubooru.func import auth, oidc, posts, users, util
 
 _cache_time = None  # type: Optional[datetime]
 _cache_result = None  # type: Optional[int]
@@ -46,6 +46,10 @@ def get_info(ctx: rest.Context, _params: Dict[str, str] = {}) -> rest.Response:
             "enableSafety": config.config["enable_safety"],
             "contactEmail": config.config["contact_email"],
             "canSendMails": bool(config.config["smtp"]["host"]),
+            "oidcEnabled": oidc.is_enabled(),
+            "oidcButtonLabel": (config.config.get("oidc") or {}).get("button_label") or "Log in with SSO",
+            "oidcButtonIcon": (config.config.get("oidc") or {}).get("button_icon") or None,
+            "disablePasswordAuth": bool((config.config.get("oidc") or {}).get("disable_password_auth", False)),
             "privileges": util.snake_case_to_lower_camel_case_keys(
                 config.config["privileges"]
             ),

--- a/server/szurubooru/api/oidc_api.py
+++ b/server/szurubooru/api/oidc_api.py
@@ -1,0 +1,22 @@
+from typing import Dict
+
+from szurubooru import rest
+from szurubooru.func import oidc
+
+
+@rest.routes.get("/auth/oidc/?")
+def get_oidc_authorization(
+    ctx: rest.Context, _params: Dict[str, str] = {}
+) -> rest.Response:
+    authorization_url, state = oidc.get_authorization_url()
+    return {"authorizationUrl": authorization_url, "state": state}
+
+
+@rest.routes.post("/auth/oidc/?")
+def exchange_oidc_code(
+    ctx: rest.Context, _params: Dict[str, str] = {}
+) -> rest.Response:
+    code = ctx.get_param_as_string("code")
+    state = ctx.get_param_as_string("state")
+    user, token = oidc.exchange_code(code, state)
+    return {"userName": user.name, "token": token.token}

--- a/server/szurubooru/api/user_api.py
+++ b/server/szurubooru/api/user_api.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from szurubooru import model, rest, search
+from szurubooru import config, errors, model, rest, search
 from szurubooru.func import auth, serialization, users, versions
 
 _search_executor = search.Executor(search.configs.UserSearchConfig())
@@ -32,6 +32,10 @@ def create_user(
     ctx: rest.Context, _params: Dict[str, str] = {}
 ) -> rest.Response:
     if ctx.user.user_id is None:
+        if (config.config.get("oidc") or {}).get("disable_password_auth"):
+            raise errors.AuthError(
+                "Password registration is disabled. Please use SSO."
+            )
         auth.verify_privilege(ctx.user, "users:create:self")
     else:
         auth.verify_privilege(ctx.user, "users:create:any")

--- a/server/szurubooru/api/user_token_api.py
+++ b/server/szurubooru/api/user_token_api.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from szurubooru import model, rest
+from szurubooru import config, model, rest
 from szurubooru.func import auth, serialization, user_tokens, users, versions
 
 
@@ -42,6 +42,9 @@ def create_user_token(
         user_tokens.update_user_token_expiration_time(
             user_token, expiration_time
         )
+    else:
+        default_expiry = int(config.config.get("token_expiry") or 0)
+        user_tokens.apply_expiry_seconds(user_token, default_expiry)
     ctx.session.add(user_token)
     ctx.session.commit()
     return _serialize(ctx, user_token)

--- a/server/szurubooru/func/oidc.py
+++ b/server/szurubooru/func/oidc.py
@@ -307,6 +307,10 @@ def exchange_code(
 
     token = user_tokens.create_user_token(user, enabled=True)
     token.note = "OIDC Login"
+    oidc_expiry = oidc.get("expires")
+    if oidc_expiry is None:
+        oidc_expiry = config.config.get("token_expiry") or 0
+    user_tokens.apply_expiry_seconds(token, int(oidc_expiry))
     db.session.add(token)
     user.last_login_time = datetime.utcnow()
     db.session.commit()

--- a/server/szurubooru/func/oidc.py
+++ b/server/szurubooru/func/oidc.py
@@ -1,0 +1,313 @@
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from typing import Dict, Optional, Tuple
+
+import sqlalchemy as sa
+
+from szurubooru import config, db, errors, model
+from szurubooru.func import auth, user_tokens
+
+
+class OidcError(errors.AuthError):
+    pass
+
+
+class OidcNotConfiguredError(errors.NotFoundError):
+    pass
+
+
+def is_enabled() -> bool:
+    oidc = config.config.get("oidc", {}) or {}
+    return bool(
+        oidc.get("client_id")
+        and oidc.get("client_secret")
+        and oidc.get("issuer")
+    )
+
+
+_discovery_cache: Optional[Dict] = None
+_discovery_cache_time: float = 0.0
+
+
+def _get_discovery() -> Dict:
+    global _discovery_cache, _discovery_cache_time
+    if _discovery_cache is not None and (time.time() - _discovery_cache_time) < 3600:
+        return _discovery_cache
+
+    oidc = config.config.get("oidc", {}) or {}
+    issuer = (oidc.get("issuer") or "").rstrip("/")
+    if not issuer:
+        raise OidcNotConfiguredError("OIDC is not configured.")
+
+    url = issuer + "/.well-known/openid-configuration"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as ex:
+        raise OidcError("Failed to fetch OIDC discovery document: %s" % ex)
+
+    _discovery_cache = data
+    _discovery_cache_time = time.time()
+    return _discovery_cache
+
+
+def generate_state() -> str:
+    nonce = os.urandom(16).hex()
+    ts = str(int(time.time()))
+    data = "%s:%s" % (nonce, ts)
+    sig = hmac.new(
+        config.config["secret"].encode("utf-8"),
+        data.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return "%s:%s" % (data, sig)
+
+
+def verify_state(state: str) -> bool:
+    try:
+        last = state.rfind(":")
+        if last < 0:
+            return False
+        data, sig = state[:last], state[last + 1:]
+        expected = hmac.new(
+            config.config["secret"].encode("utf-8"),
+            data.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(expected, sig):
+            return False
+        ts_str = data.split(":")[-1]
+        return abs(int(time.time()) - int(ts_str)) <= 600
+    except Exception:
+        return False
+
+
+def get_authorization_url() -> Tuple[str, str]:
+    if not is_enabled():
+        raise OidcNotConfiguredError("OIDC is not configured.")
+    discovery = _get_discovery()
+    oidc = config.config.get("oidc", {}) or {}
+    state = generate_state()
+    params = {
+        "response_type": "code",
+        "client_id": oidc["client_id"],
+        "redirect_uri": oidc.get("redirect_uri") or "",
+        "scope": oidc.get("scopes") or "openid email profile",
+        "state": state,
+    }
+    url = (
+        discovery["authorization_endpoint"]
+        + "?"
+        + urllib.parse.urlencode(params)
+    )
+    return url, state
+
+
+def _post_form(url: str, data: Dict) -> Dict:
+    body = urllib.parse.urlencode(data).encode("ascii")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as ex:
+        body_text = ex.read().decode("utf-8", errors="replace")
+        raise OidcError(
+            "Token endpoint returned HTTP %d: %s" % (ex.code, body_text[:300])
+        )
+    except Exception as ex:
+        raise OidcError("Token request failed: %s" % ex)
+
+
+def _decode_id_token(token: str, oidc: Dict) -> Dict:
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise ValueError("not a 3-part JWT")
+        remainder = len(parts[1]) % 4
+        padded = parts[1] + ("=" * (4 - remainder) if remainder else "")
+        claims = json.loads(
+            base64.urlsafe_b64decode(padded).decode("utf-8")
+        )
+    except Exception as ex:
+        raise OidcError("Failed to decode ID token: %s" % ex)
+
+    issuer = (oidc.get("issuer") or "").rstrip("/")
+    token_iss = (claims.get("iss") or "").rstrip("/")
+    if token_iss != issuer:
+        raise OidcError(
+            "ID token issuer mismatch: expected %r, got %r" % (issuer, token_iss)
+        )
+
+    aud = claims.get("aud")
+    client_id = oidc.get("client_id") or ""
+    aud_list = [aud] if isinstance(aud, str) else (aud or [])
+    if client_id not in aud_list:
+        raise OidcError("ID token audience does not include this client.")
+
+    if int(claims.get("exp") or 0) < int(time.time()):
+        raise OidcError("ID token has expired.")
+
+    return claims
+
+
+def _fetch_avatar(url: str) -> Optional[bytes]:
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "szurubooru"}
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.read()
+    except Exception:
+        return None
+
+
+def _sanitize_username(name: str) -> str:
+    name = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+    name = name[:32].strip("_")
+    return name or "user"
+
+
+def _find_or_create_user(
+    subject: str, display_name: str, email: str, avatar_url: str
+) -> model.User:
+    from szurubooru.func import users, util
+
+    user = (
+        db.session.query(model.User)
+        .filter(model.User.oidc_subject == subject)
+        .one_or_none()
+    )
+    if user:
+        return user
+
+    if email:
+        user = (
+            db.session.query(model.User)
+            .filter(sa.func.lower(model.User.email) == email.lower())
+            .one_or_none()
+        )
+        if user:
+            user.oidc_subject = subject
+            return user
+
+    # --- new user from here on ---
+
+    oidc = config.config.get("oidc", {}) or {}
+    # PyYAML parses yes/no as True/False booleans
+    if not oidc.get("allow_registration", True):
+        raise OidcError(
+            "No account is linked to this identity. "
+            "Contact an administrator to link your account."
+        )
+
+    base = (
+        _sanitize_username(display_name)
+        if display_name
+        else (_sanitize_username(email.split("@")[0]) if email else "user")
+    )
+
+    name = base
+    counter = 1
+    while users.try_get_user_by_name(name):
+        name = "%s%d" % (base, counter)
+        counter += 1
+
+    user = model.User()
+    user.name = name
+    user.password_hash = "!"
+    user.password_salt = ""
+    user.password_revision = 0
+    user.email = email or None
+    user.oidc_subject = subject
+    user.rank = (
+        model.User.RANK_ADMINISTRATOR
+        if users.get_user_count() == 0
+        else util.flip(auth.RANK_MAP)[config.config["default_rank"]]
+    )
+    user.creation_time = datetime.utcnow()
+    user.avatar_style = model.User.AVATAR_GRAVATAR
+    db.session.add(user)
+
+    if avatar_url:
+        avatar_bytes = _fetch_avatar(avatar_url)
+        if avatar_bytes:
+            try:
+                users.update_user_avatar(user, "manual", avatar_bytes)
+            except Exception:
+                pass  # fall back to gravatar silently
+
+    return user
+
+
+def exchange_code(
+    code: str, state: str
+) -> Tuple[model.User, model.UserToken]:
+    if not is_enabled():
+        raise OidcNotConfiguredError("OIDC is not configured.")
+    if not verify_state(state):
+        raise OidcError("Invalid or expired OIDC state parameter.")
+
+    discovery = _get_discovery()
+    oidc = config.config.get("oidc", {}) or {}
+
+    token_data = _post_form(
+        discovery["token_endpoint"],
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": oidc.get("redirect_uri") or "",
+            "client_id": oidc["client_id"],
+            "client_secret": oidc["client_secret"],
+        },
+    )
+
+    if "error" in token_data:
+        raise OidcError(
+            "OIDC provider error: %s"
+            % token_data.get("error_description", token_data["error"])
+        )
+
+    id_token = token_data.get("id_token")
+    if not id_token:
+        raise OidcError("OIDC provider did not return an id_token.")
+
+    claims = _decode_id_token(id_token, oidc)
+
+    subject = claims.get("sub")
+    if not subject:
+        raise OidcError("ID token is missing the 'sub' claim.")
+
+    email = claims.get("email") or ""
+    display_name = (
+        claims.get("preferred_username")
+        or claims.get("nickname")
+        or claims.get("name")
+        or ""
+    )
+    avatar_claim = (oidc.get("avatar_claim") or "picture") or "picture"
+    avatar_url = str(claims.get(avatar_claim) or "")
+
+    user = _find_or_create_user(
+        str(subject), str(display_name), str(email), avatar_url
+    )
+
+    token = user_tokens.create_user_token(user, enabled=True)
+    token.note = "OIDC Login"
+    db.session.add(token)
+    user.last_login_time = datetime.utcnow()
+    db.session.commit()
+    return user, token

--- a/server/szurubooru/func/user_tokens.py
+++ b/server/szurubooru/func/user_tokens.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional
 
 import pytz
@@ -148,3 +148,10 @@ def update_user_token_note(user_token: model.UserToken, note: str) -> None:
 def bump_usage_time(user_token: model.UserToken) -> None:
     assert user_token
     user_token.last_usage_time = datetime.utcnow()
+
+
+def apply_expiry_seconds(user_token: model.UserToken, seconds: int) -> None:
+    """Set token expiry from a duration in seconds. 0 means no expiry."""
+    if seconds and seconds > 0:
+        user_token.expiration_time = datetime.utcnow() + timedelta(seconds=seconds)
+        update_user_token_edit_time(user_token)

--- a/server/szurubooru/middleware/authenticator.py
+++ b/server/szurubooru/middleware/authenticator.py
@@ -1,7 +1,7 @@
 import base64
 from typing import Optional, Tuple
 
-from szurubooru import errors, model, rest
+from szurubooru import config, errors, model, rest
 from szurubooru.func import auth, user_tokens, users
 from szurubooru.rest.errors import HttpBadRequest
 
@@ -34,6 +34,10 @@ def _get_user(ctx: rest.Context, bump_login: bool) -> Optional[model.User]:
     try:
         auth_type, credentials = ctx.get_header("Authorization").split(" ", 1)
         if auth_type.lower() == "basic":
+            if (config.config.get("oidc") or {}).get("disable_password_auth"):
+                raise errors.AuthError(
+                    "Password authentication is disabled. Please use SSO."
+                )
             username, password = (
                 base64.decodebytes(credentials.encode("ascii"))
                 .decode("utf8")

--- a/server/szurubooru/migrations/versions/516093f0ad52_add_oidc_subject_to_user.py
+++ b/server/szurubooru/migrations/versions/516093f0ad52_add_oidc_subject_to_user.py
@@ -1,0 +1,28 @@
+'''
+add_oidc_subject_to_user
+
+Revision ID: 516093f0ad52
+Created at: 2026-06-24 08:05:21.791859
+'''
+
+import sqlalchemy as sa
+from alembic import op
+
+
+
+revision = '516093f0ad52'
+down_revision = '5b5c940b4e78'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column(
+        "user",
+        sa.Column("oidc_subject", sa.Unicode(length=256), nullable=True),
+    )
+    op.create_unique_constraint("uq_user_oidc_subject", "user", ["oidc_subject"])
+
+
+def downgrade():
+    op.drop_constraint("uq_user_oidc_subject", "user", type_="unique")
+    op.drop_column("user", "oidc_subject")

--- a/server/szurubooru/model/user.py
+++ b/server/szurubooru/model/user.py
@@ -34,6 +34,7 @@ class User(Base):
     avatar_style = sa.Column(
         "avatar_style", sa.Unicode(32), nullable=False, default=AVATAR_GRAVATAR
     )
+    oidc_subject = sa.Column("oidc_subject", sa.Unicode(256), nullable=True, unique=True)
 
     comments = sa.orm.relationship("Comment")
 


### PR DESCRIPTION
Adds OIDC Support for login

Configurable with the server config:
```yaml
# OpenID Connect (OIDC) single sign-on
# Set client_id, client_secret, and issuer to enable SSO login.
# redirect_uri must be your site's base URL (the SPA root), registered with
# your OIDC provider exactly as written here.
oidc:
    client_id:       # example: my-client
    client_secret:   # example: mysecret
    issuer:          # example: https://auth.example.com
    # must be registered with your OIDC provider and must point to your site root
    redirect_uri:    # example: https://example.com
    scopes: 'openid email profile'
    # set to no to prevent automatic account creation on first OIDC login
    allow_registration: yes
    # disable username/password login and self-registration; users must log in via SSO
    disable_password_auth: no
    # optional custom label for the SSO button (default: 'Log in with SSO')
    button_label:
    # optional URL to an icon image shown on the SSO button
    button_icon:
    # OIDC claim containing the user's avatar/profile picture URL
    # standard value is 'picture'; leave blank to disable avatar import
    avatar_claim: picture
 ```
 
 You can:
- Setup OpenID Connect
- Disable password logins
- Disable new accounts
- Customise login button
- Auto-load a users avatar.

In the future, there could be a potential for roles based on the OIDC claims too, such as with PocketID's groups. 