### PR TITLE
Add search history to search bar

### DIFF
--- a/client/css/core-forms.styl
+++ b/client/css/core-forms.styl
@@ -370,18 +370,42 @@ input[type=file]:focus+.file-dropper,
                 display: block
                 padding: 0.1em 0.5em
                 transition: none
-            &.active a, a:hover
+             &.active a, a:hover
                 background: $button-enabled-background-color
                 color: $button-enabled-text-color
-                span
+                span, .clear-history, .show-more-history
                     color: $button-enabled-text-color
-            .disabled
+            .disabled, .clear-history, .show-more-history
                 color: $inactive-link-color
+            &.history
+                position: relative
+                a
+                    padding-right: 2.2em
+                .remove-history
+                    position: absolute
+                    right: 0.6em
+                    top: 50%
+                    transform: translateY(-50%)
+                    cursor: pointer
+                    color: $inactive-link-color
+                    font-weight: bold
+                    font-size: 1.1em
+                    z-index: 1
+                    &:hover
+                        color: #f44
+                &.active, &:hover
+                    .remove-history
+                        color: rgba(255, 255, 255, 0.7)
+                        &:hover
+                            color: #ff8888
 
 .darktheme .autocomplete
     background: $window-color-darktheme
-    ul li .disabled
-        color: $inactive-link-color-darktheme
+    ul li
+        .disabled, .clear-history, .show-more-history
+            color: $inactive-link-color-darktheme
+        &.history .remove-history
+            color: $inactive-link-color-darktheme
 
 .anticomplete
     display: none

--- a/client/html/settings.tpl
+++ b/client/html/settings.tpl
@@ -90,6 +90,20 @@
                 }) %>
                 <p class='hint'>Display all underscores as if they were spaces. This is only a visual change, which means that you'll still have to use underscores when searching or editing tags.</p>
             </li>
+
+            <li>
+                <%= ctx.makeCheckbox({
+                    text: 'Enable search history',
+                    name: 'search-history-enabled',
+                    checked: ctx.browsingSettings.searchHistoryEnabled,
+                }) %>
+                <p class='hint'>Save and show your previous search queries.</p>
+            </li>
+
+            <li>
+                <input type='button' id='clear-search-history' class='discourage' value='Clear search history'/>
+                <p class='hint'>Delete all saved search queries from this browser.</p>
+            </li>
         </ul>
 
         <div class='messages'></div>

--- a/client/js/controllers/post_list_controller.js
+++ b/client/js/controllers/post_list_controller.js
@@ -10,6 +10,7 @@ const PageController = require("../controllers/page_controller.js");
 const PostsHeaderView = require("../views/posts_header_view.js");
 const PostsPageView = require("../views/posts_page_view.js");
 const EmptyView = require("../views/empty_view.js");
+const searchHistory = require("../util/search_history.js");
 
 const fields = [
     "id",
@@ -136,7 +137,6 @@ class PostListController {
 
     _syncPageController() {
         if (this._ctx.parameters.query) {
-            const searchHistory = require("../util/search_history.js");
             searchHistory.addQueryToHistory(this._ctx.parameters.query);
         }
         this._pageController.run({

--- a/client/js/controllers/post_list_controller.js
+++ b/client/js/controllers/post_list_controller.js
@@ -135,6 +135,10 @@ class PostListController {
     }
 
     _syncPageController() {
+        if (this._ctx.parameters.query) {
+            const searchHistory = require("../util/search_history.js");
+            searchHistory.addQueryToHistory(this._ctx.parameters.query);
+        }
         this._pageController.run({
             parameters: this._ctx.parameters,
             defaultLimit: parseInt(settings.get().postsPerPage),

--- a/client/js/controllers/settings_controller.js
+++ b/client/js/controllers/settings_controller.js
@@ -12,6 +12,11 @@ class SettingsController {
             settings: settings.get(),
         });
         this._view.addEventListener("submit", (e) => this._evtSubmit(e));
+        this._view.addEventListener("clearHistory", () => {
+            const searchHistory = require("../util/search_history.js");
+            searchHistory.clearQueryHistory();
+            this._view.showSuccess("Search history cleared.");
+        });
     }
 
     _evtSubmit(e) {

--- a/client/js/controls/auto_complete_control.js
+++ b/client/js/controls/auto_complete_control.js
@@ -40,6 +40,8 @@ class AutoCompleteControl {
         this._showTimeout = null;
         this._results = [];
         this._activeResult = -1;
+        this._isHistoryExpanded = false;
+        this._historyLimit = 10;
 
         this._install();
     }
@@ -48,6 +50,8 @@ class AutoCompleteControl {
         window.clearTimeout(this._showTimeout);
         this._suggestionDiv.style.display = "none";
         this._isVisible = false;
+        this._isHistoryExpanded = false;
+        this._historyLimit = 10;
     }
 
     replaceSelectedText(result, addSpace) {
@@ -81,10 +85,26 @@ class AutoCompleteControl {
     _delete(result) {
         if (this._options.delete) {
             this._options.delete(result);
+            if (this._options.getHistoryMatches && !this._sourceInputNode.value) {
+                this._updateHistoryResults();
+            }
         }
     }
 
     _confirm(result) {
+        if (result && result.isShowMore) {
+            this._isHistoryExpanded = true;
+            this._historyLimit = (this._historyLimit || 10) + 10;
+            this._updateHistoryResults();
+            return;
+        }
+        if (result && result.isClearHistory) {
+            if (this._options.clearHistory) {
+                this._options.clearHistory();
+            }
+            this.hide();
+            return;
+        }
         if (this._options.confirm) {
             this._options.confirm(result);
         } else {
@@ -100,10 +120,40 @@ class AutoCompleteControl {
     _showOrHide() {
         const textToFind = this._options.getTextToFind();
         if (!textToFind || !textToFind.length) {
-            this.hide();
+            if (this._options.getHistoryMatches && !this._sourceInputNode.value) {
+                this._updateHistoryResults();
+            } else {
+                this.hide();
+            }
         } else {
             this._updateResults(textToFind);
         }
+    }
+
+    _updateHistoryResults() {
+        this._options.getHistoryMatches().then((matches) => {
+            const oldResults = this._results.slice();
+            const limit = this._isHistoryExpanded ? (this._historyLimit || 10) : 10;
+            this._results = matches.slice(0, limit);
+            if (matches.length > limit) {
+                this._results.push({
+                    caption: '<span class="show-more-history"><i class="fa fa-chevron-down"></i> Show more</span>',
+                    value: { isShowMore: true }
+                });
+            }
+            if (this._results.length > 0 && this._options.clearHistory) {
+                this._results.push({
+                    caption: '<span class="clear-history"><i class="fa fa-trash"></i> Clear search history</span>',
+                    value: { isClearHistory: true }
+                });
+            }
+            const oldResultsHash = JSON.stringify(oldResults);
+            const newResultsHash = JSON.stringify(this._results);
+            if (oldResultsHash !== newResultsHash) {
+                this._activeResult = -1;
+            }
+            this._refreshList();
+        });
     }
 
     _install() {
@@ -123,6 +173,12 @@ class AutoCompleteControl {
         );
         this._sourceInputNode.addEventListener("blur", (e) =>
             this._evtBlur(e)
+        );
+        this._sourceInputNode.addEventListener("focus", (e) =>
+            this._evtFocus(e)
+        );
+        this._sourceInputNode.addEventListener("click", (e) =>
+            this._evtClick(e)
         );
 
         this._suggestionDiv = views.htmlToDom(
@@ -168,8 +224,11 @@ class AutoCompleteControl {
                 };
             } else if (key === "Enter" && this._activeResult >= 0) {
                 func = () => {
-                    this._confirm(this._getActiveSuggestion());
-                    this.hide();
+                    const activeSuggestion = this._getActiveSuggestion();
+                    this._confirm(activeSuggestion);
+                    if (!activeSuggestion || !activeSuggestion.isShowMore) {
+                        this.hide();
+                    }
                 };
             } else if (key === "Delete" && this._activeResult >= 0) {
                 func = () => {
@@ -197,6 +256,14 @@ class AutoCompleteControl {
         window.setTimeout(() => {
             this.hide();
         }, 50);
+    }
+
+    _evtFocus(e) {
+        this._showOrHide();
+    }
+
+    _evtClick(e) {
+        this._showOrHide();
     }
 
     _getActiveSuggestion() {
@@ -261,10 +328,26 @@ class AutoCompleteControl {
         for (let [resultIndex, resultItem] of this._results.entries()) {
             let resultIndexWorkaround = resultIndex;
             const listItem = document.createElement("li");
+            if (resultItem.isHistory) {
+                listItem.classList.add("history");
+            }
             const link = document.createElement("a");
             link.innerHTML = resultItem.caption;
             link.setAttribute("href", "");
-            link.setAttribute("data-key", resultItem.value._origName);
+            if (resultItem.value && resultItem.value._origName) {
+                link.setAttribute("data-key", resultItem.value._origName);
+            }
+            if (resultItem.isHistory) {
+                const removeLink = document.createElement("span");
+                removeLink.className = "remove-history";
+                removeLink.innerHTML = "&times;";
+                removeLink.addEventListener("mousedown", (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    this._delete(resultItem.value);
+                });
+                listItem.appendChild(removeLink);
+            }
             link.addEventListener("mouseenter", (e) => {
                 e.preventDefault();
                 this._activeResult = resultIndexWorkaround;
@@ -273,8 +356,14 @@ class AutoCompleteControl {
             link.addEventListener("mousedown", (e) => {
                 e.preventDefault();
                 this._activeResult = resultIndexWorkaround;
-                this._confirm(this._getActiveSuggestion());
-                this.hide();
+                const activeSuggestion = this._getActiveSuggestion();
+                this._confirm(activeSuggestion);
+                if (!activeSuggestion || !activeSuggestion.isShowMore) {
+                    this.hide();
+                }
+            });
+            link.addEventListener("click", (e) => {
+                e.preventDefault();
             });
             listItem.appendChild(link);
             this._suggestionList.appendChild(listItem);

--- a/client/js/controls/tag_auto_complete_control.js
+++ b/client/js/controls/tag_auto_complete_control.js
@@ -4,6 +4,7 @@ const misc = require("../util/misc.js");
 const views = require("../util/views.js");
 const TagList = require("../models/tag_list.js");
 const AutoCompleteControl = require("./auto_complete_control.js");
+const searchHistory = require("../util/search_history.js");
 
 function _tagListToMatches(text, tags, options, negated) {
     return [...tags]
@@ -78,7 +79,6 @@ class TagAutoCompleteControl extends AutoCompleteControl {
         };
 
         if (options.enableHistory) {
-            const searchHistory = require("../util/search_history.js");
             options.getHistoryMatches = () => {
                 return new Promise((resolve) => {
                     const history = searchHistory.getQueryHistory();

--- a/client/js/controls/tag_auto_complete_control.js
+++ b/client/js/controls/tag_auto_complete_control.js
@@ -77,6 +77,34 @@ class TagAutoCompleteControl extends AutoCompleteControl {
             });
         };
 
+        if (options.enableHistory) {
+            const searchHistory = require("../util/search_history.js");
+            options.getHistoryMatches = () => {
+                return new Promise((resolve) => {
+                    const history = searchHistory.getQueryHistory();
+                    const matches = history.map((query) => {
+                        return {
+                            caption: `<span class="history-item"><i class="fa fa-history"></i> ${misc.escapeHtml(query)}</span>`,
+                            isHistory: true,
+                            value: {
+                                isHistory: true,
+                                value: query,
+                            },
+                        };
+                    });
+                    resolve(matches);
+                });
+            };
+            options.delete = (item) => {
+                if (item && item.isHistory) {
+                    searchHistory.removeQueryFromHistory(item.value);
+                }
+            };
+            options.clearHistory = () => {
+                searchHistory.clearQueryHistory();
+            };
+        }
+
         super(input, options);
     }
 
@@ -85,6 +113,9 @@ class TagAutoCompleteControl extends AutoCompleteControl {
             return null;
         }
         const result = this._results[this._activeResult].value;
+        if (result && (result.isHistory || result.isClearHistory || result.isShowMore)) {
+            return result;
+        }
         const textToFind = this._options.getTextToFind();
         result.matchingNames = misc.matchingNames(textToFind, result.names);
         return result;

--- a/client/js/models/settings.js
+++ b/client/js/models/settings.js
@@ -19,6 +19,7 @@ const defaultSettings = {
     tagUnderscoresAsSpaces: false,
     darkTheme: false,
     postFlow: false,
+    searchHistoryEnabled: true,
 };
 
 class Settings extends events.EventTarget {

--- a/client/js/util/search_history.js
+++ b/client/js/util/search_history.js
@@ -1,0 +1,82 @@
+"use strict";
+
+const MAX_HISTORY_ITEMS = 50;
+const HISTORY_KEY = "szurubooru-search-history-anonymous";
+
+function getQueryHistory() {
+    const settings = require("../models/settings.js");
+    if (settings.get().searchHistoryEnabled === false) {
+        return [];
+    }
+    const api = require("../api.js");
+    if (api.userName && api.user) {
+        try {
+            return api.user.searchHistory ? JSON.parse(api.user.searchHistory) : [];
+        } catch (e) {
+            return [];
+        }
+    }
+    try {
+        const item = localStorage.getItem(HISTORY_KEY);
+        return item ? JSON.parse(item) : [];
+    } catch (e) {
+        return [];
+    }
+}
+
+function addQueryToHistory(query) {
+    const settings = require("../models/settings.js");
+    if (settings.get().searchHistoryEnabled === false) {
+        return;
+    }
+    if (!query || !query.trim()) return;
+    query = query.trim();
+    let history = getQueryHistory();
+    history = history.filter((q) => q !== query);
+    history.unshift(query);
+    if (history.length > MAX_HISTORY_ITEMS) {
+        history = history.slice(0, MAX_HISTORY_ITEMS);
+    }
+    saveHistory(history);
+}
+
+function removeQueryFromHistory(query) {
+    let history = getQueryHistory();
+    history = history.filter((q) => q !== query);
+    saveHistory(history);
+}
+
+function clearQueryHistory() {
+    saveHistory([]);
+}
+
+function saveHistory(history) {
+    const api = require("../api.js");
+    if (api.userName && api.user) {
+        api.user.searchHistory = JSON.stringify(history);
+        api.put("/user/" + api.userName, {
+            version: api.user.version,
+            searchHistory: api.user.searchHistory
+        }).then(
+            (response) => {
+                api.user = response;
+            },
+            (err) => {
+                console.error("Failed to save search history to account:", err);
+            }
+        );
+    } else {
+        try {
+            localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+        } catch (e) {
+            // Ignore quota/access errors
+        }
+    }
+}
+
+module.exports = {
+    getQueryHistory: getQueryHistory,
+    addQueryToHistory: addQueryToHistory,
+    removeQueryFromHistory: removeQueryFromHistory,
+    clearQueryHistory: clearQueryHistory,
+};

--- a/client/js/util/search_history.js
+++ b/client/js/util/search_history.js
@@ -1,14 +1,16 @@
 "use strict";
 
+const api = require("../api.js");
+const settings = require("../models/settings.js");
+const uri = require("./uri.js");
+
 const MAX_HISTORY_ITEMS = 50;
 const HISTORY_KEY = "szurubooru-search-history-anonymous";
 
 function getQueryHistory() {
-    const settings = require("../models/settings.js");
     if (settings.get().searchHistoryEnabled === false) {
         return [];
     }
-    const api = require("../api.js");
     if (api.userName && api.user) {
         try {
             return api.user.searchHistory ? JSON.parse(api.user.searchHistory) : [];
@@ -25,7 +27,6 @@ function getQueryHistory() {
 }
 
 function addQueryToHistory(query) {
-    const settings = require("../models/settings.js");
     if (settings.get().searchHistoryEnabled === false) {
         return;
     }
@@ -51,10 +52,9 @@ function clearQueryHistory() {
 }
 
 function saveHistory(history) {
-    const api = require("../api.js");
     if (api.userName && api.user) {
         api.user.searchHistory = JSON.stringify(history);
-        api.put("/user/" + api.userName, {
+        api.put(uri.formatApiLink("user", api.userName), {
             version: api.user.version,
             searchHistory: api.user.searchHistory
         }).then(

--- a/client/js/views/home_view.js
+++ b/client/js/views/home_view.js
@@ -25,12 +25,19 @@ class HomeView {
             this._autoCompleteControl = new TagAutoCompleteControl(
                 this._searchInputNode,
                 {
-                    confirm: (tag) =>
-                        this._autoCompleteControl.replaceSelectedText(
-                            misc.escapeSearchTerm(tag.matchingNames[0]),
-                            true
-                        ),
+                    confirm: (item) => {
+                        if (item.isHistory) {
+                            this._searchInputNode.value = item.value;
+                            this._evtFormSubmit(new Event("submit"));
+                        } else {
+                            this._autoCompleteControl.replaceSelectedText(
+                                misc.escapeSearchTerm(item.matchingNames[0]),
+                                true
+                            );
+                        }
+                    },
                     isNegationAllowed: true,
+                    enableHistory: true,
                 }
             );
             this._formNode.addEventListener("submit", (e) =>

--- a/client/js/views/posts_header_view.js
+++ b/client/js/views/posts_header_view.js
@@ -181,12 +181,19 @@ class PostsHeaderView extends events.EventTarget {
         this._autoCompleteControl = new TagAutoCompleteControl(
             this._queryInputNode,
             {
-                confirm: (tag) =>
-                    this._autoCompleteControl.replaceSelectedText(
-                        misc.escapeSearchTerm(tag.matchingNames[0]),
-                        true
-                    ),
+                confirm: (item) => {
+                    if (item.isHistory) {
+                        this._queryInputNode.value = item.value;
+                        this._navigate();
+                    } else {
+                        this._autoCompleteControl.replaceSelectedText(
+                            misc.escapeSearchTerm(item.matchingNames[0]),
+                            true
+                        );
+                    }
+                },
                 isNegationAllowed: true,
+                enableHistory: true,
             }
         );
 

--- a/client/js/views/settings_view.js
+++ b/client/js/views/settings_view.js
@@ -18,6 +18,16 @@ class SettingsView extends events.EventTarget {
 
         views.decorateValidator(this._formNode);
         this._formNode.addEventListener("submit", (e) => this._evtSubmit(e));
+
+        const clearHistoryBtn = this._hostNode.querySelector("#clear-search-history");
+        if (clearHistoryBtn) {
+            clearHistoryBtn.addEventListener("click", (e) => {
+                e.preventDefault();
+                if (confirm("Are you sure you want to clear your search history?")) {
+                    this.dispatchEvent(new CustomEvent("clearHistory"));
+                }
+            });
+        }
     }
 
     clearMessages() {
@@ -46,6 +56,7 @@ class SettingsView extends events.EventTarget {
                         .checked,
                     darkTheme: this._find("dark-theme").checked,
                     postFlow: this._find("post-flow").checked,
+                    searchHistoryEnabled: this._find("search-history-enabled").checked,
                 },
             })
         );

--- a/server/szurubooru/api/user_api.py
+++ b/server/szurubooru/api/user_api.py
@@ -87,6 +87,9 @@ def update_user(ctx: rest.Context, params: Dict[str, str]) -> rest.Response:
             ctx.get_param_as_string("avatarStyle"),
             ctx.get_file("avatar", default=b""),
         )
+    if ctx.has_param("searchHistory"):
+        auth.verify_privilege(ctx.user, "users:edit:%s:email" % infix)
+        users.update_user_search_history(user, ctx.get_param_as_string("searchHistory"))
     ctx.session.commit()
     return _serialize(ctx, user)
 

--- a/server/szurubooru/func/users.py
+++ b/server/szurubooru/func/users.py
@@ -117,7 +117,13 @@ class UserSerializer(serialization.BaseSerializer):
             "likedPostCount": self.serialize_liked_post_count,
             "dislikedPostCount": self.serialize_disliked_post_count,
             "email": self.serialize_email,
+            "searchHistory": self.serialize_search_history,
         }
+
+    def serialize_search_history(self) -> Any:
+        if (self.auth_user and self.user and self.auth_user.user_id == self.user.user_id) or (self.auth_user and self.auth_user.rank in (model.User.RANK_MODERATOR, model.User.RANK_ADMINISTRATOR)):
+            return self.user.search_history
+        return None
 
     def serialize_name(self) -> Any:
         return self.user.name
@@ -337,3 +343,8 @@ def reset_user_password(user: model.User) -> str:
     user.password_hash = password_hash
     user.password_revision = revision
     return password
+
+
+def update_user_search_history(user: model.User, search_history: str) -> None:
+    assert user
+    user.search_history = search_history

--- a/server/szurubooru/migrations/versions/78a78b08ca7a_add_user_search_history.py
+++ b/server/szurubooru/migrations/versions/78a78b08ca7a_add_user_search_history.py
@@ -1,0 +1,22 @@
+'''
+add user search history
+
+Revision ID: 78a78b08ca7a
+Created at: 2026-06-29 12:07:53.780064
+'''
+
+import sqlalchemy as sa
+from alembic import op
+
+
+
+revision = '78a78b08ca7a'
+down_revision = '5b5c940b4e78'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column("user", sa.Column("search_history", sa.Text, nullable=True))
+
+def downgrade():
+    op.drop_column("user", "search_history")

--- a/server/szurubooru/model/user.py
+++ b/server/szurubooru/model/user.py
@@ -34,6 +34,7 @@ class User(Base):
     avatar_style = sa.Column(
         "avatar_style", sa.Unicode(32), nullable=False, default=AVATAR_GRAVATAR
     )
+    search_history = sa.Column("search_history", sa.Text, nullable=True)
 
     comments = sa.orm.relationship("Comment")
 


### PR DESCRIPTION
Closes #768
This PR implements a client-side search history feature to the search bar.

## Features
- Searches will be stored per-account and synced across devices
- Leaving the search bar empty will show 10 recent searches, pressing the "Show more" button shows 10 more
- stores a max of 50 searches
- disable search history and clear it in the settings