### PR TITLE
Add Smilingwolf wd-tagger as an automatic tagger for posts

### DIFF
--- a/client/css/tag-input-control.styl
+++ b/client/css/tag-input-control.styl
@@ -159,3 +159,7 @@ div.tag-input, ul.compact-tags
     div.tag-input, ul.compact-tags
         .tag-usages, .tag-weight, .remove-tag
             color: $inactive-link-color-darktheme
+
+.auto-tag-btn
+    width: 100%
+    margin-top: 0.5em

--- a/client/html/post_edit_sidebar.tpl
+++ b/client/html/post_edit_sidebar.tpl
@@ -70,6 +70,9 @@
         <% if (ctx.canEditPostTags) { %>
             <section class='tags'>
                 <%= ctx.makeTextInput({}) %>
+                <% if (ctx.taggerEnabled && ctx.post.type === 'image') { %>
+                    <button type='button' class='auto-tag-btn'>Auto-tag image</button>
+                <% } %>
             </section>
         <% } %>
 

--- a/client/js/api.js
+++ b/client/js/api.js
@@ -108,6 +108,10 @@ class Api extends events.EventTarget {
         return !!remoteConfig.enableSafety;
     }
 
+    taggerEnabled() {
+        return !!remoteConfig.taggerEnabled;
+    }
+
     hasPrivilege(lookup) {
         let minViableRank = null;
         for (let p of Object.keys(remoteConfig.privileges)) {

--- a/client/js/controls/post_edit_sidebar_control.js
+++ b/client/js/controls/post_edit_sidebar_control.js
@@ -29,6 +29,7 @@ class PostEditSidebarControl extends events.EventTarget {
             template({
                 post: this._post,
                 enableSafety: api.safetyEnabled(),
+                taggerEnabled: api.taggerEnabled(),
                 hasClipboard: document.queryCommandSupported("copy"),
                 canEditPostSafety: api.hasPrivilege("posts:edit:safety"),
                 canEditPostSource: api.hasPrivilege("posts:edit:source"),
@@ -89,6 +90,12 @@ class PostEditSidebarControl extends events.EventTarget {
         if (this._formNode) {
             this._formNode.addEventListener("submit", (e) =>
                 this._evtSubmit(e)
+            );
+        }
+
+        if (this._autoTagBtnNode) {
+            this._autoTagBtnNode.addEventListener("click", (e) =>
+                this._evtAutoTagClick(e)
             );
         }
 
@@ -391,6 +398,36 @@ class PostEditSidebarControl extends events.EventTarget {
         this._postNotesOverlayControl.switchToPassiveEdit();
     }
 
+    _evtAutoTagClick(e) {
+        e.preventDefault();
+        if (!this._autoTagBtnNode) return;
+        this._autoTagBtnNode.setAttribute("disabled", "disabled");
+        this._autoTagBtnNode.textContent = "Tagging...";
+        this._post.getAutoTags()
+            .then((response) => {
+                const addPromises = response.tags.map((tag) => {
+                    return this._tagControl.addTagByName(tag.name, "suggestions");
+                });
+                return Promise.all(addPromises).then(() => {
+                    if (response.safety && this._safetyButtonNodes.length) {
+                        for (let node of this._safetyButtonNodes) {
+                            if (node.value.toLowerCase() === response.safety.toLowerCase()) {
+                                node.checked = true;
+                                node.dispatchEvent(new Event("change"));
+                            }
+                        }
+                    }
+                    this._autoTagBtnNode.removeAttribute("disabled");
+                    this._autoTagBtnNode.textContent = "Auto-tag image";
+                });
+            })
+            .catch((err) => {
+                this._autoTagBtnNode.removeAttribute("disabled");
+                this._autoTagBtnNode.textContent = "Auto-tag image";
+                alert(err.message || "Failed to auto-tag image.");
+            });
+    }
+
     _evtSubmit(e) {
         e.preventDefault();
         this.dispatchEvent(
@@ -445,6 +482,10 @@ class PostEditSidebarControl extends events.EventTarget {
 
     get _submitButtonNode() {
         return this._hostNode.querySelector(".submit");
+    }
+
+    get _autoTagBtnNode() {
+        return this._formNode.querySelector(".auto-tag-btn");
     }
 
     get _safetyButtonNodes() {

--- a/client/js/models/post.js
+++ b/client/js/models/post.js
@@ -326,6 +326,10 @@ class Post extends events.EventTarget {
             );
     }
 
+    getAutoTags() {
+        return api.get(uri.formatApiLink("post", this.id, "auto-tags"));
+    }
+
     feature() {
         return api
             .post(uri.formatApiLink("featured-post"), { id: this._id })

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,6 +49,14 @@ services:
     volumes:
       - "sql:/var/lib/postgresql/data"
 
+  tagger:
+    build:
+      context: ./tagger
+    volumes:
+      - "./server/config.yaml:/opt/app/config.yaml"
+      - "hf_cache:/data/huggingface_cache"
+
 volumes:
   data:
   sql:
+  hf_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,3 +44,13 @@ services:
       POSTGRES_PASSWORD:
     volumes:
       - "${MOUNT_SQL}:/var/lib/postgresql/data"
+
+  tagger:
+    image: szurubooru/tagger:latest
+    restart: unless-stopped
+    volumes:
+      - "./server/config.yaml:/opt/app/config.yaml"
+      - "hf_cache:/data/huggingface_cache"
+
+volumes:
+  hf_cache:

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -169,6 +169,26 @@ privileges:
     'uploads:create':               regular
     'uploads:use_downloader':       power
 
+# auto-tagger configuration
+tagger:
+    enabled: false
+    auto_tag_on_upload: true
+    url: http://tagger:8000
+    model: SmilingWolf/wd-eva02-large-tagger-v3
+    # Map tagger classes (general, character) to szuruboorus tag category names
+    category_mappings:
+        general: general
+        character: character
+    classify_safety: true
+    # Map models 4 safety ratings (general, sensitive, questionable, explicit) to szuruboorus 3 safety ratings (safe, sketchy, unsafe)
+    safety_mappings:
+        general: safe
+        sensitive: sketchy
+        questionable: sketchy
+        explicit: unsafe
+    # Threshold for predicting tags (0.0 to 1.0)
+    threshold: 0.35
+
 ## ONLY SET THESE IF DEPLOYING OUTSIDE OF DOCKER
 #debug: 0 # generate server logs?
 #show_sql: 0 # show sql in server logs?

--- a/server/szurubooru/api/info_api.py
+++ b/server/szurubooru/api/info_api.py
@@ -44,6 +44,7 @@ def get_info(ctx: rest.Context, _params: Dict[str, str] = {}) -> rest.Response:
             "tagCategoryNameRegex": config.config["tag_category_name_regex"],
             "defaultUserRank": config.config["default_rank"],
             "enableSafety": config.config["enable_safety"],
+            "taggerEnabled": config.config.get("tagger", {}).get("enabled", False),
             "contactEmail": config.config["contact_email"],
             "canSendMails": bool(config.config["smtp"]["host"]),
             "privileges": util.snake_case_to_lower_camel_case_keys(

--- a/server/szurubooru/api/post_api.py
+++ b/server/szurubooru/api/post_api.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from szurubooru import db, errors, model, rest, search
+from szurubooru import config, db, errors, model, rest, search
 from szurubooru.func import (
     auth,
     favorites,
+    files,
     mime,
     posts,
     scores,
@@ -307,4 +308,45 @@ def get_posts_by_image(
             }
             for distance, post in lookalikes
         ],
+    }
+
+
+@rest.routes.get("/post/(?P<post_id>[^/]+)/auto-tags/?")
+def get_post_auto_tags(
+    ctx: rest.Context, params: Dict[str, str]
+) -> rest.Response:
+    auth.verify_privilege(ctx.user, "posts:edit:tags")
+    post_id = int(params["post_id"])
+    post = posts.get_post_by_id(post_id)
+    if post.type != model.Post.TYPE_IMAGE:
+        raise errors.ValidationError("Only image posts can be auto-tagged.")
+
+    # Read image content
+    content = files.get(posts.get_post_content_path(post))
+
+    # Run tagger
+    from szurubooru.func import tagger
+    res = tagger.get_tags_from_tagger(content)
+    if not res:
+        raise errors.ThirdPartyError("Tagger service returned no tags or is unavailable.")
+
+    tags_list, auto_safety = res
+    # Map category types
+    tagger_conf = config.config.get("tagger", {})
+    mapped_categories = tagger_conf.get("category_mappings", {
+        "general": "general",
+        "character": "character"
+    })
+
+    ret_tags = []
+    for name, cat in tags_list:
+        db_category = mapped_categories.get(cat, cat)
+        ret_tags.append({
+            "name": name,
+            "category": db_category
+        })
+
+    return {
+        "tags": ret_tags,
+        "safety": auto_safety
     }

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -419,7 +419,38 @@ def create_post(
     post.mime_type = ""
 
     update_post_content(post, content)
-    new_tags = update_post_tags(post, tag_names)
+
+    auto_tags = []
+    auto_safety = None
+    category_mappings = {}
+
+    from szurubooru.func import tagger
+    if (
+        post.type == model.Post.TYPE_IMAGE
+        and tagger.is_tagger_enabled()
+        and config.config.get("tagger", {}).get("auto_tag_on_upload", True)
+    ):
+        res = tagger.get_tags_from_tagger(content)
+        if res:
+            tags_list, auto_safety = res
+            tagger_conf = config.config.get("tagger", {})
+            mapped_categories = tagger_conf.get("category_mappings", {
+                "general": "general",
+                "character": "character"
+            })
+            for name, cat in tags_list:
+                db_category = mapped_categories.get(cat, cat)
+                category_mappings[name.lower()] = db_category
+                auto_tags.append(name)
+
+            if auto_safety:
+                post._auto_safety = auto_safety
+
+    all_tag_names = list(util.icase_unique(tag_names + auto_tags))
+    if category_mappings:
+        new_tags = update_post_tags(post, all_tag_names, category_mappings)
+    else:
+        new_tags = update_post_tags(post, all_tag_names)
 
     db.session.add(post)
     return post, new_tags
@@ -427,6 +458,8 @@ def create_post(
 
 def update_post_safety(post: model.Post, safety: str) -> None:
     assert post
+    if hasattr(post, "_auto_safety") and getattr(post, "_auto_safety") is not None:
+        safety = getattr(post, "_auto_safety")
     safety = util.flip(SAFETY_MAP).get(safety, None)
     if not safety:
         raise InvalidPostSafetyError(
@@ -696,10 +729,17 @@ def generate_post_thumbnail(post: model.Post) -> None:
 
 
 def update_post_tags(
-    post: model.Post, tag_names: List[str]
+    post: model.Post,
+    tag_names: List[str],
+    category_mappings: Optional[Dict[str, str]] = None,
 ) -> List[model.Tag]:
     assert post
-    existing_tags, new_tags = tags.get_or_create_tags_by_names(tag_names)
+    if category_mappings is not None:
+        existing_tags, new_tags = tags.get_or_create_tags_by_names(
+            tag_names, category_mappings
+        )
+    else:
+        existing_tags, new_tags = tags.get_or_create_tags_by_names(tag_names)
     post.tags = existing_tags + new_tags
     return new_tags
 

--- a/server/szurubooru/func/tagger.py
+++ b/server/szurubooru/func/tagger.py
@@ -1,0 +1,58 @@
+import json
+import logging
+import urllib.request
+import urllib.error
+from typing import Dict, List, Tuple, Optional
+from szurubooru import config
+
+logger = logging.getLogger(__name__)
+
+def is_tagger_enabled() -> bool:
+    tagger_conf = config.config.get("tagger", {})
+    return bool(tagger_conf.get("enabled", False))
+
+def get_tags_from_tagger(image_content: bytes) -> Optional[Tuple[List[Tuple[str, str]], Optional[str]]]:
+    """
+    Sends the image bytes to the tagger microservice.
+    Returns:
+        Tuple: (list of (tag_name, tag_category), predicted_safety_rating) or None on failure.
+    """
+    if not is_tagger_enabled():
+        return None
+
+    tagger_conf = config.config.get("tagger", {})
+    tagger_url = tagger_conf.get("url", "http://tagger:8000")
+    if not tagger_url:
+        return None
+
+    url = f"{tagger_url.rstrip('/')}/tag"
+    req = urllib.request.Request(url, data=image_content)
+    req.add_header("Content-Type", "application/octet-stream")
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as res:
+            response_data = json.loads(res.read().decode("utf-8"))
+    except Exception as ex:
+        logger.error(f"Error communicating with tagger service at {url}: {ex}")
+        if not config.config.get("allow_broken_uploads", False):
+            raise
+        return None
+
+    tags_list = []
+    for item in response_data.get("tags", []):
+        tags_list.append((item["name"], item["category"]))
+
+    ratings = response_data.get("ratings", {})
+    predicted_safety = None
+    if ratings and tagger_conf.get("classify_safety", True):
+        # Find the highest scoring safety rating
+        highest_rating = max(ratings, key=ratings.get)
+        safety_mappings = tagger_conf.get("safety_mappings", {
+            "general": "safe",
+            "sensitive": "sketchy",
+            "questionable": "sketchy",
+            "explicit": "unsafe"
+        })
+        predicted_safety = safety_mappings.get(highest_rating, "safe")
+
+    return tags_list, predicted_safety

--- a/server/szurubooru/func/tags.py
+++ b/server/szurubooru/func/tags.py
@@ -179,11 +179,12 @@ def get_tags_by_names(names: List[str]) -> List[model.Tag]:
 
 def get_or_create_tags_by_names(
     names: List[str],
+    category_mappings: Optional[Dict[str, str]] = None,
 ) -> Tuple[List[model.Tag], List[model.Tag]]:
     names = util.icase_unique(names)
     existing_tags = get_tags_by_names(names)
     new_tags = []
-    tag_category_name = tag_categories.get_default_category_name()
+    default_category_name = tag_categories.get_default_category_name()
     for name in names:
         found = False
         for existing_tag in existing_tags:
@@ -193,9 +194,24 @@ def get_or_create_tags_by_names(
                 found = True
                 break
         if not found:
+            category_name = default_category_name
+            if category_mappings:
+                mapped_name = category_mappings.get(name.lower())
+                if mapped_name:
+                    category_name = mapped_name
+
+            # Ensure tag category exists
+            try:
+                tag_categories.get_category_by_name(category_name)
+            except tag_categories.TagCategoryNotFoundError:
+                # Create category
+                new_cat = tag_categories.create_category(category_name, "default", 1)
+                db.session.add(new_cat)
+                db.session.flush()
+
             new_tag = create_tag(
                 names=[name],
-                category_name=tag_category_name,
+                category_name=category_name,
                 suggestions=[],
                 implications=[],
             )

--- a/server/szurubooru/tests/func/test_tagger.py
+++ b/server/szurubooru/tests/func/test_tagger.py
@@ -1,0 +1,174 @@
+import pytest
+import copy
+from unittest.mock import patch, MagicMock
+import urllib.error
+from szurubooru import db, model, config
+from szurubooru.func import posts, tags, tagger, tag_categories
+
+def test_is_tagger_enabled(config_injector):
+    custom_config = copy.deepcopy(config.config)
+    custom_config["tagger"] = {"enabled": True}
+    config_injector(custom_config)
+    assert tagger.is_tagger_enabled() is True
+
+    custom_config = copy.deepcopy(config.config)
+    custom_config["tagger"] = {"enabled": False}
+    config_injector(custom_config)
+    assert tagger.is_tagger_enabled() is False
+
+    custom_config = copy.deepcopy(config.config)
+    if "tagger" in custom_config:
+        del custom_config["tagger"]
+    config_injector(custom_config)
+    assert tagger.is_tagger_enabled() is False
+
+@patch("urllib.request.urlopen")
+def test_get_tags_from_tagger_disabled(mock_urlopen, config_injector):
+    custom_config = copy.deepcopy(config.config)
+    custom_config["tagger"] = {"enabled": False}
+    config_injector(custom_config)
+    res = tagger.get_tags_from_tagger(b"image_content")
+    assert res is None
+    mock_urlopen.assert_not_called()
+
+@patch("urllib.request.urlopen")
+def test_get_tags_from_tagger_success(mock_urlopen, config_injector):
+    custom_config = copy.deepcopy(config.config)
+    custom_config["tagger"] = {
+        "enabled": True,
+        "url": "http://tagger:8000",
+        "classify_safety": True,
+        "safety_mappings": {
+            "general": "safe",
+            "sensitive": "sketchy",
+            "questionable": "sketchy",
+            "explicit": "unsafe"
+        }
+    }
+    config_injector(custom_config)
+    
+    mock_res = MagicMock()
+    mock_res.read.return_value = b'{"tags": [{"name": "1girl", "category": "general"}, {"name": "miku", "category": "character"}], "ratings": {"general": 0.1, "sensitive": 0.8, "questionable": 0.05, "explicit": 0.05}}'
+    mock_urlopen.return_value.__enter__.return_value = mock_res
+
+    res = tagger.get_tags_from_tagger(b"image_content")
+    assert res == ([("1girl", "general"), ("miku", "character")], "sketchy")
+
+@patch("urllib.request.urlopen")
+def test_get_tags_from_tagger_error(mock_urlopen, config_injector):
+    custom_config = copy.deepcopy(config.config)
+    custom_config["tagger"] = {
+        "enabled": True,
+        "url": "http://tagger:8000"
+    }
+    custom_config["allow_broken_uploads"] = False
+    config_injector(custom_config)
+    
+    mock_urlopen.side_effect = urllib.error.URLError("Tagger offline")
+    with pytest.raises(urllib.error.URLError):
+        tagger.get_tags_from_tagger(b"image_content")
+
+    custom_config = copy.deepcopy(config.config)
+    custom_config["tagger"] = {
+        "enabled": True,
+        "url": "http://tagger:8000"
+    }
+    custom_config["allow_broken_uploads"] = True
+    config_injector(custom_config)
+    res = tagger.get_tags_from_tagger(b"image_content")
+    assert res is None
+
+@patch("szurubooru.func.posts.generate_post_thumbnail")
+@patch("szurubooru.func.files.save")
+@patch("szurubooru.func.tagger.is_tagger_enabled")
+@patch("szurubooru.func.tagger.get_tags_from_tagger")
+def test_create_post_with_tagger(mock_get_tags, mock_enabled, mock_save, mock_gen_thumb, config_injector, user_factory, tag_category_factory):
+    # Ensure default category exists
+    default_cat = tag_category_factory(name="default", default=True)
+    db.session.add(default_cat)
+    db.session.flush()
+
+    mock_enabled.return_value = True
+    mock_get_tags.return_value = (
+        [("1girl", "general"), ("hatsune_miku", "character")],
+        "sketchy"
+    )
+    
+    custom_config = copy.deepcopy(config.config)
+    custom_config["tagger"] = {
+        "enabled": True,
+        "url": "http://tagger:8000",
+        "category_mappings": {
+            "general": "general",
+            "character": "character"
+        }
+    }
+    custom_config["allow_broken_uploads"] = False
+    config_injector(custom_config)
+
+    content = b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
+    
+    user = user_factory()
+    
+    post, new_tags = posts.create_post(content, ["manual_tag"], user)
+    
+    assert hasattr(post, "_auto_safety")
+    assert post._auto_safety == "sketchy"
+    posts.update_post_safety(post, "safe")
+    assert post.safety == model.Post.SAFETY_SKETCHY
+    
+    tag_names = [t.first_name for t in post.tags]
+    assert "manual_tag" in tag_names
+    assert "1girl" in tag_names
+    assert "hatsune_miku" in tag_names
+    
+    t_1girl = next(t for t in post.tags if t.first_name == "1girl")
+    t_miku = next(t for t in post.tags if t.first_name == "hatsune_miku")
+    
+    assert t_1girl.category.name == "general"
+    assert t_miku.category.name == "character"
+
+
+@patch("szurubooru.func.files.get")
+@patch("szurubooru.func.tagger.get_tags_from_tagger")
+def test_get_post_auto_tags_api(mock_get_tags, mock_files_get, config_injector, post_factory, context_factory, user_factory):
+    from szurubooru import api
+    
+    post = post_factory(type=model.Post.TYPE_IMAGE)
+    db.session.add(post)
+    db.session.commit()
+    
+    mock_files_get.return_value = b"image content"
+    mock_get_tags.return_value = (
+        [("1girl", "general"), ("hatsune_miku", "character")],
+        "sketchy"
+    )
+    
+    custom_config = copy.deepcopy(config.config)
+    custom_config["tagger"] = {
+        "enabled": True,
+        "url": "http://tagger:8000",
+        "category_mappings": {
+            "general": "general",
+            "character": "character"
+        }
+    }
+    custom_config["privileges"] = {
+        "posts:edit:tags": model.User.RANK_REGULAR
+    }
+    config_injector(custom_config)
+    
+    ctx = context_factory(user=user_factory(rank=model.User.RANK_REGULAR))
+    res = api.post_api.get_post_auto_tags(ctx, {"post_id": str(post.post_id)})
+    
+    assert res == {
+        "tags": [
+            {"name": "1girl", "category": "general"},
+            {"name": "hatsune_miku", "category": "character"}
+        ],
+        "safety": "sketchy"
+    }
+    
+    mock_files_get.assert_called_once()
+    mock_get_tags.assert_called_once_with(b"image content")
+

--- a/tagger/Dockerfile
+++ b/tagger/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.10-slim
+
+WORKDIR /opt/app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+ENV HF_HOME=/data/huggingface_cache
+ENV PYTHONUNBUFFERED=1
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tagger/requirements.txt
+++ b/tagger/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+onnxruntime==1.18.0
+numpy==1.26.4
+Pillow==10.3.0
+huggingface-hub==0.23.4
+pyyaml==6.0.1
+pillow-heif==0.16.0
+pillow-avif-plugin==1.4.3

--- a/tagger/server.py
+++ b/tagger/server.py
@@ -1,0 +1,171 @@
+import os
+import io
+import csv
+import yaml
+import numpy as np
+from PIL import Image
+import pillow_avif
+from pillow_heif import register_heif_opener
+register_heif_opener()
+import onnxruntime as ort
+from huggingface_hub import hf_hub_download
+from fastapi import FastAPI, Request, Response, HTTPException
+
+app = FastAPI()
+
+def load_config():
+    config_paths = ["config.yaml", "/opt/app/config.yaml", "../server/config.yaml"]
+    for path in config_paths:
+        if os.path.exists(path):
+            try:
+                with open(path, "r") as f:
+                    return yaml.safe_load(f) or {}
+            except Exception as e:
+                print(f"Error reading config at {path}: {e}")
+    return {}
+
+config = load_config()
+tagger_config = config.get("tagger", {})
+model_name = tagger_config.get("model", "SmilingWolf/wd-eva02-large-tagger-v3")
+
+print(f"Loading SmilingWolf tagger model: {model_name}")
+
+try:
+    model_path = hf_hub_download(repo_id=model_name, filename="model.onnx")
+    csv_path = hf_hub_download(repo_id=model_name, filename="selected_tags.csv")
+except Exception as e:
+    print(f"Failed to download/load model from Hugging Face: {e}")
+    # If Hugging Face is offline, we'll catch it here and raise errors during request handling instead of failing startup
+    model_path = None
+    csv_path = None
+
+# Group tag indexes by category
+general_tags = []
+character_tags = []
+rating_tags = []
+
+if csv_path:
+    with open(csv_path, "r", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header row
+        for i, row in enumerate(reader):
+            if not row:
+                continue
+            tag_name = row[1]
+            category = int(row[2])
+            if category == 0:
+                general_tags.append((i, tag_name))
+            elif category == 4:
+                character_tags.append((i, tag_name))
+            elif category == 9:
+                rating_tags.append((i, tag_name))
+
+# Set up ONNX runtime session
+if model_path:
+    session = ort.InferenceSession(model_path)
+    input_name = session.get_inputs()[0].name
+    input_shape = session.get_inputs()[0].shape
+
+    # Dynamically find the model's expected resolution and layout (NCHW vs NHWC)
+    if input_shape[1] == 3:
+        target_size = input_shape[2]
+        is_nchw = True
+    elif input_shape[3] == 3:
+        target_size = input_shape[1]
+        is_nchw = False
+    else:
+        target_size = 448
+        is_nchw = False
+    print(f"Model input: {input_name}, shape: {input_shape}, target_size: {target_size}, NCHW: {is_nchw}")
+else:
+    session = None
+    target_size = 448
+    is_nchw = False
+
+@app.get("/health")
+async def health():
+    if not session:
+        return {"status": "error", "message": "Model not loaded"}
+    return {"status": "ok", "model": model_name, "target_size": target_size, "is_nchw": is_nchw}
+
+@app.post("/tag")
+async def tag_image(request: Request, threshold: float = None):
+    if not session:
+        raise HTTPException(status_code=500, detail="Model session is not initialized")
+    
+    if threshold is None:
+        threshold = tagger_config.get("threshold", 0.35)
+        
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=400, detail="Empty request body")
+        
+    try:
+        image = Image.open(io.BytesIO(body))
+        
+        # Convert transparency to white background
+        if image.mode in ("RGBA", "LA") or "transparency" in image.info:
+            image = image.convert("RGBA")
+            background = Image.new("RGB", image.size, (255, 255, 255))
+            background.paste(image, mask=image.split()[3])
+            image = background
+        else:
+            image = image.convert("RGB")
+            
+        # Pad image to make it square
+        width, height = image.size
+        size = max(width, height)
+        padded = Image.new("RGB", (size, size), (255, 255, 255))
+        padded.paste(image, ((size - width) // 2, (size - height) // 2))
+        
+        # Resize to expected model size
+        try:
+            resample_filter = Image.Resampling.LANCZOS
+        except AttributeError:
+            resample_filter = Image.ANTIALIAS
+        resized = padded.resize((target_size, target_size), resample_filter)
+        
+        # Convert to BGR array (needed for SmilingWolf models)
+        img_array = np.array(resized, dtype=np.float32)
+        img_array = img_array[:, :, ::-1]  # RGB to BGR
+        
+        if is_nchw:
+            img_array = img_array.transpose((2, 0, 1))
+            
+        img_array = np.expand_dims(img_array, axis=0)
+        
+        # Run ONNX model prediction
+        outputs = session.run(None, {input_name: img_array})
+        scores = outputs[0][0]
+        
+        # Filter predictions above threshold
+        result_tags = []
+        for idx, tag_name in general_tags:
+            prob = float(scores[idx])
+            if prob >= threshold:
+                result_tags.append({
+                    "name": tag_name,
+                    "category": "general",
+                    "probability": prob
+                })
+                
+        for idx, tag_name in character_tags:
+            prob = float(scores[idx])
+            if prob >= threshold:
+                result_tags.append({
+                    "name": tag_name,
+                    "category": "character",
+                    "probability": prob
+                })
+                
+        # Get safety ratings
+        ratings = {}
+        for idx, tag_name in rating_tags:
+            ratings[tag_name] = float(scores[idx])
+            
+        return {
+            "tags": result_tags,
+            "ratings": ratings
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
This PR adds an automatic image tagger using any [SmilingWolf](https://huggingface.co/SmilingWolf) model.
The tagger is deployed as a docker container.

## Features
- Automatically tags every image upon upload
- Safety classification (safe, sketchy, unsafe)
- Tags will be put into categories (general, character)
- Manual per-image tagging in the post edit menu
- Supports uncommon image formats like AVIF

All settings including what model to use are inside ./server/config.yaml.