### PR TITLE
fix batched snapshot db commits

### DIFF
--- a/server/szurubooru/model/util.py
+++ b/server/szurubooru/model/util.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import sqlalchemy as sa
 
@@ -6,7 +6,7 @@ from szurubooru.model.base import Base
 from szurubooru.model.user import User
 
 
-def get_resource_info(entity: Base) -> Tuple[Any, Any, Union[str, int]]:
+def get_resource_info(entity: Base) -> Tuple[Any, Any, str]:
     serializers = {
         "tag": lambda tag: tag.first_name,
         "tag_category": lambda category: category.name,
@@ -23,7 +23,7 @@ def get_resource_info(entity: Base) -> Tuple[Any, Any, Union[str, int]]:
     assert primary_key is not None
     assert len(primary_key) == 1
 
-    resource_name = serializers[resource_type](entity)  # type: Union[str, int]
+    resource_name = str(serializers[resource_type](entity))  # type: str
     assert resource_name
 
     resource_pkey = primary_key[0]  # type: Any

--- a/server/szurubooru/tests/func/test_snapshots_bulk_insert.py
+++ b/server/szurubooru/tests/func/test_snapshots_bulk_insert.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+import sqlalchemy.orm as sa_orm
+
+from szurubooru import db, model
+from szurubooru.func import snapshots
+
+
+@pytest.fixture(autouse=True)
+def session(query_logger, _pg_engine):
+    """
+    Commits db session and forces autoflush to False.
+    Needed to reproduce batched Snapshot inserts as seen in production.
+    """
+    session = sa_orm.Session(bind=_pg_engine, autoflush=False)
+    db.session = session
+    model.Base.metadata.create_all(_pg_engine, checkfirst=True)
+    try:
+        yield session
+    finally:
+        session.close()
+        with _pg_engine.connect() as conn:
+            conn.execute(sa.text("DROP SCHEMA public CASCADE"))
+            conn.execute(sa.text("CREATE SCHEMA public"))
+            conn.commit()
+
+
+def test_create_batches_post_and_new_tag_snapshots(
+    post_factory, tag_factory, user_factory
+):
+    """
+    tests a mix of both an int resource_name (post)
+    and a str resource_name (tag) in a batched INSERT
+    """
+    post = post_factory(id=1)
+    tag = tag_factory(names=["dummy-tag"])
+    user = user_factory()
+    db.session.add_all([post, tag, user])
+    db.session.flush()
+
+    with patch("szurubooru.func.snapshots.get_post_snapshot"), patch(
+        "szurubooru.func.snapshots.get_tag_snapshot"
+    ), patch("szurubooru.func.snapshots._post_to_webhooks"):
+        snapshots.get_post_snapshot.return_value = "mocked-post"
+        snapshots.get_tag_snapshot.return_value = "mocked-tag"
+        snapshots.create(post, user)
+        snapshots.create(tag, user)
+
+    db.session.commit()
+
+    results = db.session.query(model.Snapshot).all()
+    assert len(results) == 2
+    by_type = {result.resource_type: result for result in results}
+    assert by_type["post"].resource_name == str(post.post_id)
+    assert by_type["post"].resource_pkey == post.post_id
+    assert by_type["tag"].resource_name == tag.first_name
+    assert by_type["tag"].resource_pkey == tag.tag_id


### PR DESCRIPTION
Closes #780

Fixes a regression caused by the SQLAlchemy 2.0 migration. Not an expert on SA so apologies if I butcher this explanation:

SA2.0 introduced a feature where it "bundles" multiple statements into a single transaction. For most queries, that works perfectly fine, but for insertions into the snapshots table, that can cause issues because posts and tags have different identifiers (int vs str) and when combined together in the same transaction, SA/Postgres doesn't auto-cast the int to a str anymore.

The way to trigger this is to create a new post and tag simultaneously in the same REST query. The web UI never does this so it wasn't caught.

It's also not covered in the existing unit tests, so I added one for it.